### PR TITLE
feature(ci): add actions workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -22,7 +22,6 @@ permissions:
   attestations: write
 
 env:
-  # Static metadata; safe for forks
   IMAGE_DESCRIPTION: Campfire is a web-based chat application with multiple rooms, direct messages, file attachments with previews, search, web push notifications, @mentions, and bot integrations. Single-tenant; production-ready image with web app, background jobs, caching, file serving, and SSL.
   SOURCE_URL: https://github.com/${{ github.repository }}
 
@@ -93,6 +92,7 @@ jobs:
           file: Dockerfile
           build-args: |
             OCI_SOURCE=${{ env.SOURCE_URL }}
+            OCI_DESCRIPTION=${{ env.IMAGE_DESCRIPTION }}
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 FROM base
 
 # Image metadata
-LABEL org.opencontainers.image.description="Campfire is a web-based chat application with multiple rooms, direct messages, file attachments with previews, search, web push notifications, @mentions, and bot integrations. Single-tenant; production-ready image with web app, background jobs, caching, file serving, and SSL."
+ARG OCI_DESCRIPTION
+LABEL org.opencontainers.image.description="${OCI_DESCRIPTION}"
 ARG OCI_SOURCE
-LABEL org.opencontainers.image.source=${OCI_SOURCE}
+LABEL org.opencontainers.image.source="${OCI_SOURCE}"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Run and own only the runtime files as a non-root user for security


### PR DESCRIPTION
Thank you for making Campfire open source! 

Getting Docker images up on GHCR will seriously help users get up and running with Campfire quickly and allow for quick deployment with Unraid, Kubernetes, etc. I've also made the image build multi-arch, so hopefully someone in the community can test this on a Raspberry Pi or similar device (will test myself once back in Tokyo). Since this could be used by enterprises, cosign has also been added for provenance.

Campfire will also be able to (somewhat) track installations in a privacy-friendly way too. You can see an example of the image page provided by GHCR here: https://github.com/alexandernicholson/once-campfire/pkgs/container/once-campfire/505951545?tag=main

Unfortunately, these runners are not running on Minisforum MS-A2s, but if you have any suggestions on improving build times here, I'd love to know!