### PR TITLE
fix: set room instance variable in room direct destroy

### DIFF
--- a/app/controllers/rooms/directs_controller.rb
+++ b/app/controllers/rooms/directs_controller.rb
@@ -1,5 +1,5 @@
 class Rooms::DirectsController < RoomsController
-  before_action :set_room, only: %i[ edit ]
+  before_action :set_room, only: %i[ edit destroy ]
   def new
     @room = Rooms::Direct.new
   end


### PR DESCRIPTION
This fixes the issue #10 

I think the issue could be caused by my last PR #9, where I override the before_action in the child controller (app/controllers/rooms/directs_controller.rb) to set the room instance variable in the edit method.

I'm new to rails and ruby, I just read on inheritance and before_action, i'm hesitant to add show in the child controller's before_action. 

Please let me know if the current fix is adequate, I'm happy to learn more about and work more on this. Sorry about the problem caused by my last PR.