### PR TITLE
Fix back button not working on profile page after form submission

### DIFF
--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :nav do %>
   <div class="flex-item-justify-start">
-    <%= link_back %>
+    <%= link_back_to_last_room_visited %>
   </div>
 
   <div class="flex-item-justify-end">


### PR DESCRIPTION
The back button breaks on the profile page after form submission because it relies on the `referrer`. Instead, it should navigate to the last opened chat.