### PR TITLE
feature(ci): improvements to ghcr image management

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -99,8 +99,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          sbom: true
-          provenance: true
+          sbom: false
+          provenance: false
 
       - name: Attest image provenance (per-arch)
         if: github.event_name != 'pull_request'
@@ -108,7 +108,7 @@ jobs:
         with:
           subject-name: ${{ steps.vars.outputs.canonical }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false
 
   manifest:
     name: Create multi-arch manifest and sign

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - 'v*'
-  release:
-    types: [published]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -79,7 +79,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           flavor: |
-            latest=auto
+            latest=false
             suffix=-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.source=${{ env.SOURCE_URL }}
@@ -151,8 +151,9 @@ jobs:
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           flavor: |
-            latest=auto
+            latest=false
           labels: |
             org.opencontainers.image.source=${{ env.SOURCE_URL }}
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -167,17 +167,22 @@ jobs:
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             echo "Creating manifest for $tag"
+            src_tag="$tag"
+            if [[ "$tag" == *:latest && "${GITHUB_REF}" == refs/tags/* ]]; then
+              ref="${GITHUB_REF#refs/tags/}"
+              src_tag="${tag%:latest}:$ref"
+            fi
             if [ -n "${IMAGE_DESCRIPTION:-}" ]; then
               docker buildx imagetools create \
                 --tag "$tag" \
                 --annotation "index:org.opencontainers.image.description=${IMAGE_DESCRIPTION}" \
-                "${tag}-amd64" \
-                "${tag}-arm64"
+                "${src_tag}-amd64" \
+                "${src_tag}-arm64"
             else
               docker buildx imagetools create \
                 --tag "$tag" \
-                "${tag}-amd64" \
-                "${tag}-arm64"
+                "${src_tag}-amd64" \
+                "${src_tag}-arm64"
             fi
           done <<< "$tags"
 


### PR DESCRIPTION
I took some time to really optimize how images are being used for the project, in preparation for your upcoming release.

After some tweaking, I've gotten attestations except for the primary attestation to only appear on the Actions -> Attestations and GHCR's "view all versions" tab, reduced the number of images, prevented duplicate CI runs on cut releases / tags, and improved when `:latest` will be pushed (it will only be pushed on a tag). It is possible to remove signatures entirely, but for software BOMs it's kinda essential and allows you to revoke and [prevent downstream consumers from using a compromised artifact](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/manage-attestations).

After:
<img width="733" height="386" alt="Screenshot 2025-09-10 at 4 27 45" src="https://github.com/user-attachments/assets/ec34ed80-03d4-4939-b475-3d48f7871589" />

From testing in: https://github.com/alexandernicholson/once-campfire/pkgs/container/once-campfire.

Of course as always, let me know what you think and if there are any suggestions!
