### PR TITLE
Rewrite the URL to the title

### DIFF
--- a/app/helpers/content_filters.rb
+++ b/app/helpers/content_filters.rb
@@ -1,3 +1,3 @@
 module ContentFilters
-  TextMessagePresentationFilters = ActionText::Content::Filters.new(RemoveSoloUnfurledLinkText, StyleUnfurledTwitterAvatars, SanitizeTags)
+  TextMessagePresentationFilters = ActionText::Content::Filters.new(UrlTitleFilter, RemoveSoloUnfurledLinkText, StyleUnfurledTwitterAvatars, SanitizeTags)
 end

--- a/app/helpers/content_filters/url_title_filter.rb
+++ b/app/helpers/content_filters/url_title_filter.rb
@@ -1,0 +1,49 @@
+# Content filter that replaces URLs with their page titles as clickable links
+# This filter processes message content to make URLs more readable while keeping them functional
+class ContentFilters::UrlTitleFilter < ActionText::Content::Filter
+  # Check if the content contains any URLs that should be processed
+  # @return [Boolean] True if the content contains URLs
+  def applicable?
+    contains_urls?(content.to_plain_text)
+  end
+
+  # Apply the URL title replacement to the content
+  # Replaces URLs with clickable links containing the page title
+  def apply
+    plain_text = content.to_plain_text
+    processed_text = replace_urls_with_titles(plain_text)
+    
+    fragment.update do |source|
+      source.inner_html = processed_text
+    end
+  end
+
+  private
+
+  # Check if the text contains any HTTP/HTTPS URLs
+  # @param text [String] The text to check
+  # @return [Boolean] True if URLs are found
+  def contains_urls?(text)
+    text.match?(/(?:^|\s)(https?:\/\/[^\s]+)/)
+  end
+
+  # Replace URLs in text with clickable links containing page titles
+  # @param text [String] The text containing URLs
+  # @return [String] The text with URLs replaced by title links
+  def replace_urls_with_titles(text)
+    text.gsub(/(^|\s)(https?:\/\/[^\s]+)/) do |match|
+      space = $1 # space or start of line
+      url = $2   # the actual URL
+      
+      title = UrlTitleExtractor.extract_title(url)
+      
+      if title
+        # Replace URL with clickable link containing the title
+        "#{space}<a href=\"#{url}\" target=\"_blank\">#{title}</a>"
+      else
+        # Keep original URL if title extraction failed
+        match
+      end
+    end
+  end
+end

--- a/app/javascript/lib/rich_text/unfurl/unfurler.js
+++ b/app/javascript/lib/rich_text/unfurl/unfurler.js
@@ -44,6 +44,7 @@ export default class Unfurler {
     }
   }
 
+
   #editorElementPermitsAttribute(element, attributeName) {
     if (element.hasAttribute("data-permitted-attributes")) {
       return Array.from(element.getAttribute("data-permitted-attributes").split(" ")).includes(attributeName)

--- a/app/services/url_title_extractor.rb
+++ b/app/services/url_title_extractor.rb
@@ -1,0 +1,90 @@
+require 'cgi'
+require 'net/http'
+require 'uri'
+
+# Service for extracting page titles from URLs
+# Used by the UrlTitleFilter to replace URLs with their titles in chat messages
+class UrlTitleExtractor
+  # Extract the title from a given URL
+  # @param url [String] The URL to extract the title from
+  # @return [String, nil] The extracted title or nil if extraction fails
+  def self.extract_title(url)
+    return nil unless url.present?
+    return nil unless url.match?(/\Ahttps?:\/\/.+/)
+    
+    begin
+      response = fetch_page(url)
+      return nil unless response&.is_a?(Net::HTTPSuccess)
+      
+      title = extract_title_from_html(response.body)
+      return nil if title.blank?
+      
+      clean_title_text(title)
+    rescue => e
+      Rails.logger.warn "Failed to extract title from #{url}: #{e.message}"
+      nil
+    end
+  end
+
+  private
+
+  # Fetch the webpage content
+  # @param url [String] The URL to fetch
+  # @return [Net::HTTPResponse, nil] The HTTP response or nil if failed
+  def self.fetch_page(url)
+    uri = URI.parse(url)
+    
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 5, read_timeout: 5) do |http|
+      request = Net::HTTP::Get.new(uri)
+      request['User-Agent'] = 'Mozilla/5.0 (compatible; Campfire/1.0)'
+      http.request(request)
+    end
+  rescue => e
+    Rails.logger.warn "Failed to fetch #{url}: #{e.message}"
+    nil
+  end
+
+  # Extract title from HTML content using multiple strategies
+  # @param html [String] The HTML content
+  # @return [String, nil] The extracted title or nil if not found
+  def self.extract_title_from_html(html)
+    extract_from_meta_tag(html, 'og:title') ||
+      extract_from_meta_tag(html, 'twitter:title') ||
+      extract_from_title_tag(html) ||
+      extract_from_h1_tag(html)
+  end
+
+  # Extract title from OpenGraph or Twitter meta tags
+  # @param html [String] The HTML content
+  # @param property [String] The meta property name (e.g., 'og:title')
+  # @return [String, nil] The meta content or nil if not found
+  def self.extract_from_meta_tag(html, property)
+    match = html.match(/<meta[^>]+(?:property|name)=["']#{Regexp.escape(property)}["'][^>]+content=["']([^"']+)["'][^>]*>/i)
+    match ? match[1] : nil
+  end
+
+  # Extract title from HTML title tag
+  # @param html [String] The HTML content
+  # @return [String, nil] The title content or nil if not found
+  def self.extract_from_title_tag(html)
+    match = html.match(/<title[^>]*>([^<]+)<\/title>/i)
+    match ? match[1] : nil
+  end
+
+  # Extract title from HTML h1 tag as fallback
+  # @param html [String] The HTML content
+  # @return [String, nil] The h1 content or nil if not found
+  def self.extract_from_h1_tag(html)
+    match = html.match(/<h1[^>]*>([^<]+)<\/h1>/i)
+    match ? match[1] : nil
+  end
+
+  # Clean and format the extracted title
+  # @param title [String] The raw title text
+  # @return [String] The cleaned title
+  def self.clean_title_text(title)
+    title = CGI.unescapeHTML(title)
+    title = title.strip
+    title.length > 100 ? "#{title[0..96]}..." : title
+  end
+end

--- a/test/helpers/content_filters/url_title_filter_test.rb
+++ b/test/helpers/content_filters/url_title_filter_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class ContentFilters::UrlTitleFilterTest < ActiveSupport::TestCase
+  test "is applicable when content contains URLs" do
+    content = ActionText::Content.new("Check out https://example.com")
+    filter = ContentFilters::UrlTitleFilter.new(content)
+    
+    assert filter.applicable?
+  end
+
+  test "is not applicable when content contains no URLs" do
+    content = ActionText::Content.new("Just plain text")
+    filter = ContentFilters::UrlTitleFilter.new(content)
+    
+    assert_not filter.applicable?
+  end
+
+  test "is not applicable when content contains @ URLs" do
+    content = ActionText::Content.new("Check out @https://example.com")
+    filter = ContentFilters::UrlTitleFilter.new(content)
+    
+    assert_not filter.applicable?
+  end
+
+  test "contains_urls? returns true for valid URLs" do
+    filter = ContentFilters::UrlTitleFilter.new(ActionText::Content.new(""))
+    
+    assert filter.send(:contains_urls?, "https://example.com")
+    assert filter.send(:contains_urls?, "http://example.com")
+    assert filter.send(:contains_urls?, "Check out https://example.com")
+  end
+
+  test "contains_urls? returns false for invalid URLs" do
+    filter = ContentFilters::UrlTitleFilter.new(ActionText::Content.new(""))
+    
+    assert_not filter.send(:contains_urls?, "just text")
+    assert_not filter.send(:contains_urls?, "@https://example.com")
+    assert_not filter.send(:contains_urls?, "ftp://example.com")
+  end
+
+  test "replace_urls_with_titles creates clickable links" do
+    filter = ContentFilters::UrlTitleFilter.new(ActionText::Content.new(""))
+    
+    # Mock the title extractor
+    UrlTitleExtractor.stubs(:extract_title).with("https://example.com").returns("Example Domain")
+    
+    result = filter.send(:replace_urls_with_titles, "Check out https://example.com")
+    expected = 'Check out <a href="https://example.com" target="_blank">Example Domain</a>'
+    
+    assert_equal expected, result
+  end
+
+  test "replace_urls_with_titles preserves original URL when title extraction fails" do
+    filter = ContentFilters::UrlTitleFilter.new(ActionText::Content.new(""))
+    
+    # Mock the title extractor to return nil
+    UrlTitleExtractor.stubs(:extract_title).with("https://example.com").returns(nil)
+    
+    result = filter.send(:replace_urls_with_titles, "Check out https://example.com")
+    expected = "Check out https://example.com"
+    
+    assert_equal expected, result
+  end
+
+  test "replace_urls_with_titles handles multiple URLs" do
+    filter = ContentFilters::UrlTitleFilter.new(ActionText::Content.new(""))
+    
+    # Mock the title extractor
+    UrlTitleExtractor.stubs(:extract_title).with("https://example.com").returns("Example Domain")
+    UrlTitleExtractor.stubs(:extract_title).with("https://github.com").returns("GitHub")
+    
+    result = filter.send(:replace_urls_with_titles, "Check out https://example.com and https://github.com")
+    expected = 'Check out <a href="https://example.com" target="_blank">Example Domain</a> and <a href="https://github.com" target="_blank">GitHub</a>'
+    
+    assert_equal expected, result
+  end
+end

--- a/test/services/url_title_extractor_test.rb
+++ b/test/services/url_title_extractor_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class UrlTitleExtractorTest < ActiveSupport::TestCase
+  test "returns nil for invalid URL" do
+    title = UrlTitleExtractor.extract_title("not-a-url")
+    assert_nil title
+  end
+
+  test "returns nil for empty URL" do
+    title = UrlTitleExtractor.extract_title("")
+    assert_nil title
+  end
+
+  test "returns nil for nil URL" do
+    title = UrlTitleExtractor.extract_title(nil)
+    assert_nil title
+  end
+
+  test "returns nil for URL with @ symbol" do
+    title = UrlTitleExtractor.extract_title("@https://example.com")
+    assert_nil title
+  end
+
+  test "returns nil for non-HTTP URL" do
+    title = UrlTitleExtractor.extract_title("ftp://example.com")
+    assert_nil title
+  end
+
+  test "returns nil for malformed URL" do
+    title = UrlTitleExtractor.extract_title("https://")
+    assert_nil title
+  end
+end


### PR DESCRIPTION
This PR changes a URL to the title of the website, this gives the oppertunity for more clean
text in the chat, instead of a bunch of
https:// urls all over the place.