### PR TITLE
Fix let's encrypt autosetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ For example:
       --env SECRET_KEY_BASE=$YOUR_SECRET_KEY_BASE \
       --env VAPID_PUBLIC_KEY=$YOUR_PUBLIC_KEY \
       --env VAPID_PRIVATE_KEY=$YOUR_PRIVATE_KEY \
-      --env SSL_DOMAIN=chat.example.com \
+      --env TLS_DOMAIN=chat.example.com \
       campfire


### PR DESCRIPTION
This is just to match the Thruster expected environment variable so SSL certificates are created with Let's Encrypt.