### PR TITLE
[ServiceWorler fix] - Failed to get a ServiceWorkerRegistration error.

### DIFF
--- a/app/javascript/controllers/notifications_controller.js
+++ b/app/javascript/controllers/notifications_controller.js
@@ -60,8 +60,7 @@ export default class extends Controller {
   }
 
   get #serviceWorkerRegistration() {
-    const hostAndProtocol = window.location.protocol + '//' + window.location.host;
-    return navigator.serviceWorker.getRegistration(hostAndProtocol)
+    return navigator.serviceWorker.getRegistration(window.location.origin)
   }
 
   #registerServiceWorker() {


### PR DESCRIPTION
When starting Campfire locally, following error occurs, visible in browser console:
`Uncaught (in promise) SecurityError: Failed to get a ServiceWorkerRegistration: The origin of the provided documentURL ('null') does not match the current origin ('http://localhost:3000')`

Seems that the issue is mismatch of arguments in getRegistration() call.
The argument should be origin (protocol + host), but `window.location.host` is passed, which is only host without protocol.