### PR TITLE
Speed up room's initial load by reducing N+1 queries

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -32,11 +32,7 @@ class RoomsController < ApplicationController
     end
 
     def find_messages
-      messages = @room.messages.with_rich_text_body_and_embeds
-                               .with_attached_attachment
-                               .preload(creator: :avatar_attachment)
-                               .includes(attachment_blob: :variant_records)
-                               .includes(boosts: :booster)
+      messages = @room.messages.with_creator.with_attachment_details.with_boosts
 
       if show_first_message = messages.find_by(id: params[:message_id])
         @messages = messages.page_around(show_first_message)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,7 +12,13 @@ class Message < ApplicationRecord
   after_create_commit -> { room.receive(self) }
 
   scope :ordered, -> { order(:created_at) }
-  scope :with_creator, -> { includes(:creator) }
+  scope :with_creator, -> { preload(creator: :avatar_attachment) }
+  scope :with_attachment_details, -> {
+    with_rich_text_body_and_embeds
+    with_attached_attachment
+      .includes(attachment_blob: :variant_records)
+  }
+  scope :with_boosts, -> { includes(boosts: :booster) }
 
   def plain_text_body
     body.to_plain_text.presence || attachment&.filename&.to_s || ""


### PR DESCRIPTION
This is one optimization we had on the Small Bets Campfire which has improved initial speed loading of rooms (when they're not cached yet).

| Before | After |
| --- | --- |
| <img width="4144" height="2174" alt="image" src="https://github.com/user-attachments/assets/edb69d7e-d9cd-4820-8beb-1c2bf1c5e5ca" /> | <img width="2072" height="1088" alt="image" src="https://github.com/user-attachments/assets/113d0605-a3df-476d-bdc4-1bd1a260e9c8" /> |

You can clearly see the "After" flamegraph is less heavy on the page load. 

The speed increase is much more noticeable when all users have avatars uploaded. I've only tested this locally, but with the default SVG avatars using the user's initials. But in Small Bets, where there are rooms with over 7,000 people and the most active ones have avatars, you can easily notice the performance degrade when loading Campfire after a few days and try to switch between rooms with a lot of messages.