### PR TITLE
Fix setup script to handle missing mise installation automatically

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -32,14 +32,22 @@ end
 
 FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
-  system "mise install"
 
   if installed?("brew")
-    system "brew install sqlite ffmpeg"
+    system "brew install sqlite ffmpeg mise"
   elsif installed?("pacman")
-    system "sudo pacman -S --noconfirm --needed sqlite ffmpeg"
+    system "sudo pacman -S --noconfirm --needed sqlite ffmpeg mise"
   elsif installed?("apt")
     system "sudo apt-get install --no-install-recommends -y libsqlite3-0 ffmpeg"
+  end
+
+  if installed?("mise")
+    system "mise install"
+  else
+    puts "Couldn't install mise"
+    puts "Install mise using your package manager or via:"
+    puts "https://mise.jdx.dev/installing-mise.html"
+    exit 1
   end
 
   system("bundle check") || system!("bundle install")


### PR DESCRIPTION
### Problem
The setup script was failing for new developers when `mise` (the tool version manager) wasn't installed on their system. The script would exit with an unhelpful error message, requiring manual intervention to install `mise` before proceeding.

### Solution
Updated the setup script to automatically install `mise` using the appropriate package manager:

- **macOS (Homebrew)**: `brew install mise`
- **Arch Linux (pacman)**: `sudo pacman -S mise` 
- **Ubuntu/Debian (apt)**: Skipped for now as it was not working correctly while testing on docker build

### Testing
- Tested on macOS with Homebrew 
- Tested on Arch Linux with pacman