### PR TITLE
[Trix input] - max height and scroll set.

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -66,6 +66,8 @@ trix-toolbar {
 trix-editor {
   &.input {
     min-height: 24px;
+    overflow-y: auto;
+    max-height: 360px;
   }
 
   .attachment--content {


### PR DESCRIPTION
UI/UX improvemnent of the text editor component in use i.e. Trix editor.

Namely, when you start typing the message in the editor, as the message grows so does the editor's UI, up to a point that it can become as big as chat panel, and as such it obscures the previous messages i.e. chat history.

As I am aware Trix editor doesn't have regular setup for the rows, but this is achieved via CSS.

Now just to compare:

1. **MS Teams** shows **12 rows** of text without scrollbar
2. **Slack** shows **23 rows** of text without scrollbar

After the above threshold is breached, we get the scrollbar for the input text field for the above apps.

Unfortunately, Campfire doesn't have this limmit.

So, I would suggest, for the sake of better UX to make some limmits for the UI input.
It doesn't have to be so restrictive as MS Teams, but I think that it should be less then in Slack.

So, my suggestion would be to limmit it to **15 lines**, that would be `360px`, that would be equal to `2116 characters`, without scrolling (that is on most of the laptop/desktop displays).