### PR TITLE
Allow serving cable traffic under `$SCRIPT_NAME`

### DIFF
--- a/app/helpers/cable_helper.rb
+++ b/app/helpers/cable_helper.rb
@@ -1,0 +1,7 @@
+module CableHelper
+  def script_aware_action_cable_meta_tag
+    tag.meta \
+      name: "action-cable-url",
+      content: "#{request.script_name}#{ActionCable.server.config.mount_path}"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= current_user_meta_tags %>
+    <%= script_aware_action_cable_meta_tag %>
 
     <%= tag.meta name: "vapid-public-key", content: Rails.configuration.x.vapid.public_key %>
     <%= tag.meta name: "turbo-prefetch", content: "true" %>


### PR DESCRIPTION
If deploying Campfire to a path other than the root (for example, using Kamal's path-based routing) then the Action Cable endpoint needs to be adjusted to include that path.

Prepending the script name to the cable path means it will be adjusted to the path, in the same way that the application routes are. When script name is the default, the behaviour is unchanged.

/cc @monorkin 