### PR TITLE
[New Feature] - User status i.e. user presence across whole application

### DIFF
--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -201,3 +201,28 @@
     }
   }
 }
+
+.user-status {
+  border-radius: 50%;
+  border: 2px solid black;
+  width: 16px;
+  height: 16px;
+  background: gray;
+  z-index: 1;
+  position: absolute;
+  bottom: -4px;
+  left: -4px;
+}
+
+.user-status-large {
+  width: 32px;
+  height: 32px;
+}
+
+.user-status-bot-always-active {
+  background: green;
+}
+
+.user-status-container {
+  position: relative;
+}

--- a/app/channels/user_status_channel.rb
+++ b/app/channels/user_status_channel.rb
@@ -1,0 +1,55 @@
+class UserStatusChannel < ApplicationCable::Channel
+  USER_STATUS_ACTIVE = "active"
+  USER_STATUS_AWAY = "away"
+  USER_STATUS_OFFLINE = "offline"
+
+  USER_STATUES_CACHE_KEY = "user_statuses"
+
+  on_subscribe :user_status_active, unless: :subscription_rejected?
+  on_unsubscribe :user_status_offline,  unless: :subscription_rejected?
+
+
+  def subscribed
+    stream_from "user_status"
+  end
+
+  def user_status_active
+    broadcast_user_status(params[:userId], USER_STATUS_ACTIVE)
+  end
+
+  def user_status_away
+    broadcast_user_status(params[:userId], USER_STATUS_AWAY)
+  end
+
+  def user_status_offline
+    broadcast_user_status(params[:userId], USER_STATUS_OFFLINE)
+  end
+
+  def get_users_statuses
+    ActionCable.server.broadcast("user_status", get_user_status_hash)
+  end
+
+  private
+    def broadcast_user_status(user_id, status)
+      return if user_id.nil?
+
+      update_user_status_hash(user_id, status)
+      ActionCable.server.broadcast("user_status", get_user_status_hash)
+    end
+
+    def get_user_status_hash
+      Rails.cache.read(USER_STATUES_CACHE_KEY)
+    end
+
+    def update_user_status_hash(user_id, status)
+      data = get_user_status_hash
+
+      if data.nil?
+        data = {}
+      end
+
+      data[user_id] = status
+
+      Rails.cache.write(USER_STATUES_CACHE_KEY, data)
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,16 @@ module ApplicationHelper
     end
   end
 
+  def current_user_id
+    return Current.user.id unless Current.user.nil?
+
+    nil
+  end
+
+  def is_user_bot?(user)
+    user.role == "bot"
+  end
+
   private
     def admin_body_class
       "admin" if Current.user&.can_administer?

--- a/app/helpers/users/avatars_helper.rb
+++ b/app/helpers/users/avatars_helper.rb
@@ -11,8 +11,25 @@ module Users::AvatarsHelper
   end
 
   def avatar_tag(user, **options)
-    link_to user_path(user), title: user.title, class: "btn avatar", data: { turbo_frame: "_top" } do
-      image_tag fresh_user_avatar_path(user), aria: { hidden: "true" }, size: 48, **options
+    if options[:hide_status]
+      link_to user_path(user), title: user.title, class: "btn avatar user-status-container", data: { turbo_frame: "_top" } do
+        image_tag(fresh_user_avatar_path(user), aria: { hidden: "true" }, size: 48, **options)
+      end
+    else
+      link_to user_path(user), title: user.title, class: "btn avatar user-status-container", data: { turbo_frame: "_top" } do
+        image_tag(fresh_user_avatar_path(user), aria: { hidden: "true" }, size: 48, **options) +
+        user_status_tag(user, options[:large_avatar])
+      end
     end
+  end
+
+  def user_status_tag(user, large_avatar = false)
+    return content_tag(:div, "", class: "user-status user-status-bot-always-active") if is_user_bot?(user)
+
+    content_tag(:div, "", class: class_names("user-status", 'user-status-large': large_avatar), data: {
+      controller: "user-status-avatar",
+      user_status_avatar_user_id_value: user.id,
+      user_status_avatar_target: "avatar"
+    })
   end
 end

--- a/app/javascript/controllers/user_status_avatar_controller.js
+++ b/app/javascript/controllers/user_status_avatar_controller.js
@@ -1,0 +1,89 @@
+import { Controller } from "@hotwired/stimulus"
+import { cable } from "@hotwired/turbo-rails"
+import { pageIsTurboPreview } from "helpers/turbo_helpers"
+
+const OFFLINE_AFTER_DISCONNECTED_TIMEOUT = 5_000
+
+const STATUS_ACTIVE = "active"
+const STATUS_AWAY = "away"
+const STATUS_OFFLINE = "offline"
+
+export default class extends Controller {
+  static targets = [ "avatar" ]
+  static values = { userId: Number }
+
+  #offlineTimer = null
+
+  async connect() {
+    this.channel = await cable.subscribeTo({ channel: "UserStatusChannel" }, {
+      connected: this.#channelConnected.bind(this),
+      disconnected: this.#channelDisconnected.bind(this),
+      received: this.#read.bind(this)
+    })
+    this.channel.send({ action: "get_users_statuses"})
+  }
+
+  disconnect() {
+    this.channel?.unsubscribe()
+  }
+
+  online() {
+    // Trigger reconnection attempt whenever the browser comes back
+    // from being offline
+    this.channel.consumer.connection.monitor.visibilityDidChange()
+  }
+
+  #channelConnected() {
+
+    clearTimeout(this.#offlineTimer)
+    this.dispatch("online", { target: window })
+  }
+
+  #channelDisconnected() {
+    this.#offlineTimer = setTimeout(() => {
+      this.dispatch("offline", { target: window })
+    }, OFFLINE_AFTER_DISCONNECTED_TIMEOUT)
+  }
+
+  // user status logic
+
+  #read(data){
+    this.#updateUserStatuses(data)
+  }
+
+  #updateUserStatuses(data){
+    Object.entries(data).forEach(([user_id, status]) => {
+      this.#setStatus(status, user_id)
+    });
+  }
+
+  #setStatus(status, userId) {
+    if (this.userIdValue != userId) return
+
+    switch(status) {
+      case STATUS_ACTIVE:
+        this.#setStautsActive(userId)
+        break;
+      case STATUS_AWAY:
+        this.#setStatusAway(userId)
+        break;
+      case STATUS_OFFLINE:
+        this.#setStatusOffline(userId)
+        break;
+      default:
+        // nothing
+    }
+  }
+
+  #setStautsActive(userId) {
+    this.avatarTarget.style.background = "green";
+  }
+
+  #setStatusAway(userId) {
+    this.avatarTarget.style.background = "orange";
+  }
+
+  #setStatusOffline(userId) {
+    this.avatarTarget.style.background = "gray";
+  }
+}

--- a/app/javascript/controllers/user_status_controller.js
+++ b/app/javascript/controllers/user_status_controller.js
@@ -1,0 +1,120 @@
+import { Controller } from "@hotwired/stimulus"
+import { cable } from "@hotwired/turbo-rails"
+import { pageIsTurboPreview } from "helpers/turbo_helpers"
+
+const OFFLINE_AFTER_DISCONNECTED_TIMEOUT = 5_000
+const REFRESH_AFTER_HIDDEN_TIMEOUT = 60_000
+
+const STATUS_ACTIVE = "active"
+const STATUS_AWAY = "away"
+const STATUS_OFFLINE = "offline"
+
+export default class extends Controller {
+  static targets = [ "status", "main" ]
+  static values = { userId: Number }
+
+  #offlineTimer = null
+  #hiddenAt = null
+
+  async connect() {
+    if (!pageIsTurboPreview()) {
+      this.#channelDisconnected()
+
+      this.channel = await cable.subscribeTo({ channel: "UserStatusChannel", userId: this.userIdValue }, {
+        connected: this.#channelConnected.bind(this),
+        disconnected: this.#channelDisconnected.bind(this),
+      })
+      this.#setStatus(STATUS_ACTIVE, this.userIdValue)
+    }
+  }
+
+  disconnect() {
+    this.channel?.unsubscribe()
+  }
+
+  visibilityChanged(event) {
+    let userId = event.params.userId
+    if (document.visibilityState === "visible") {
+      if (this.#hiddenForTooLong()) {
+        this.dispatch("visible")
+      }
+      this.#setStatus(STATUS_ACTIVE, userId)
+      this.#hiddenAt = null
+    } else {
+      this.#hiddenAt = Date.now()
+      this.#setStatus(STATUS_AWAY, userId)
+    }
+  }
+
+  online() {
+    // Trigger reconnection attempt whenever the browser comes back
+    // from being offline
+    this.channel.consumer.connection.monitor.visibilityDidChange()
+  }
+
+  #channelConnected() {
+
+    clearTimeout(this.#offlineTimer)
+    this.dispatch("online", { target: window })
+  }
+
+  #channelDisconnected() {
+    this.#offlineTimer = setTimeout(() => {
+      this.dispatch("offline", { target: window })
+    }, OFFLINE_AFTER_DISCONNECTED_TIMEOUT)
+  }
+
+  #hiddenForTooLong() {
+    return this.#hiddenAt && Date.now() - this.#hiddenAt > REFRESH_AFTER_HIDDEN_TIMEOUT
+  }
+
+  // user status logic
+  #checkIfPresenceStatusIsApplicapble(userId) {
+    return this.#isCurrentUser(userId) && this.#checkIfTargetIsOnStatusOrMain();
+  }
+
+  #isCurrentUser(userId) {
+    if (userId === null) return false
+    return userId === Current.user.id
+  }
+
+  #checkIfTargetIsOnStatusOrMain() {
+    return this.statusTargets.length > 0 || this.mainTargets.length > 0
+  }
+
+  #setStatus(status, userId) {
+    if (!this.#checkIfPresenceStatusIsApplicapble(userId)) return;
+
+    switch(status) {
+      case STATUS_ACTIVE:
+        this.#setStautsActive(userId)
+        break;
+      case STATUS_AWAY:
+        this.#setStatusAway(userId)
+        break;
+      case STATUS_OFFLINE:
+        this.#setStatusOffline(userId)
+        break;
+      default:
+        // nothing
+    }
+  }
+
+  #setStautsActive(userId) {
+    if (!this.#checkIfPresenceStatusIsApplicapble(userId)) return;
+
+    this.channel.send({ action: "user_status_active"})
+  }
+
+  #setStatusAway(userId) {
+    if (!this.#checkIfPresenceStatusIsApplicapble(userId)) return;
+
+    this.channel.send({ action: "user_status_away"})
+  }
+
+  #setStatusOffline(userId) {
+    if (!this.#checkIfPresenceStatusIsApplicapble(userId)) return;
+
+    this.channel.send({ action: "user_status_offline"})
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,17 @@
     <%= yield :head %>
   </head>
 
+  <% if current_user_id%>
+  <body class="<%= body_classes %>"
+    data-controller="local-time lightbox user-status"
+    data-action="visibilitychange@document->user-status#visibilityChanged"
+    data-user-status-user-id-param=<%= current_user_id %>
+    data-user-status-user-id-value=<%= current_user_id %>
+    data-user-status-target="main"
+  >
+  <% else %>
   <body class="<%= body_classes %>" data-controller="local-time lightbox">
+  <% end %>
     <a href="#main-content" class="skip-navigation btn">Skip to main content</a>
 
     <nav id="nav">

--- a/app/views/messages/boosts/_boost.html.erb
+++ b/app/views/messages/boosts/_boost.html.erb
@@ -3,7 +3,7 @@
       class="boost boost-item flex-inline postion--relative max-width align-center fill-white gap"
       data-controller="boost-delete" data-boost-delete-perform-class="boost--deleting" data-boost-delete-reveal-class="expanded" data-boost-delete-booster-id-value="<%= boost.booster.id %>">
     <figure class="avatar boost__avatar flex-item-no-shrink">
-      <%= avatar_tag boost.booster, aria: { label: "#{boost.booster.name} boosted #{boost.content}" } %>
+      <%= avatar_tag boost.booster, aria: { label: "#{boost.booster.name} boosted #{boost.content}" }, hide_status: true %>
     </figure>
 
     <%= tag.span boost.content, role: "button",

--- a/app/views/messages/boosts/new.html.erb
+++ b/app/views/messages/boosts/new.html.erb
@@ -4,7 +4,7 @@
           data: { controller: "form scroll-into-view", turbo_frame: dom_id(@message, :boosting), action: "keydown.esc->form#cancel" } do |form| %>
       <label class="boost__form-label flex gap" style="--column-gap: 0.7ch;" role="button" tabindex="0" aria-label="Add a boost">
         <figure class="avatar boost__avatar flex-item-no-shrink">
-          <%= avatar_tag Current.user %>
+          <%= avatar_tag Current.user, hide_status: true %>
           <span class="for-screen-reader"><%= Current.user.name %></span>
         </figure>
 

--- a/app/views/rooms/directs/edit.html.erb
+++ b/app/views/rooms/directs/edit.html.erb
@@ -12,7 +12,7 @@
     <% users.each do | user | %>
       <div class="member flex flex-column gap fill-shade pad border-radius">
         <figure class="avatar center" style="--avatar-border-radius: 10ch; --avatar-size: 10ch;" >
-          <%= avatar_tag user, loading: :lazy %>
+          <%= avatar_tag user, loading: :lazy, large_avatar: true %>
         </figure>
 
         <strong><%= user.name %></strong>

--- a/app/views/users/_mention.html.erb
+++ b/app/views/users/_mention.html.erb
@@ -1,4 +1,4 @@
 <div class="mention" sgid="<%= user.attachable_sgid %>">
-  <%= avatar_tag user %>
+  <%= avatar_tag user, hide_status: true%>
   <%= user.name %>
 </div>

--- a/app/views/users/sidebars/rooms/_direct.html.erb
+++ b/app/views/users/sidebars/rooms/_direct.html.erb
@@ -6,14 +6,16 @@
     <% if members.many? %>
       <div class="avatar__group">
         <% members.first(4).each do |member| %>
-          <span class="avatar">
+          <span class="avatar user-status-container">
             <%= image_tag fresh_user_avatar_path(member), size: 20, aria: { hidden: "true" } %>
+            <%= user_status_tag(member) %>
           </span>
         <% end %>
       </div>
     <% else %>
-      <span class="avatar">
+      <span class="avatar user-status-container">
         <%= image_tag fresh_user_avatar_path(members.first), size: 48, aria: { hidden: "true" } %>
+        <%= user_status_tag(members.first) %>
       </span>
     <% end %>
 

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -48,7 +48,8 @@
   </div>
 
   <div class="flex align-end sidebar__tools gap justify-end">
-    <%= link_to user_profile_path, class: "btn avatar flex-item-no-shrink sidebar__tool" do %>
+    <%= link_to user_profile_path, class: "btn avatar flex-item-no-shrink sidebar__tool user-status-container" do %>
+      <%= user_status_tag(Current.user) %>
       <%= image_tag fresh_user_avatar_path(Current.user), size: 48, aria: { hidden: "true" }, style: "view-transition-name: avatar-#{Current.user.id}" %>
       <span class="for-screen-reader">My Settings</span>
     <% end %>


### PR DESCRIPTION
Since the name presence is already used in code, elsewhere, **user status** is used instead (in the code and description).

### User status main properties:
- Lightweight, doesn't use DB, but rather **in-memory cache**.
- Statuses are: **Active**(green), **Away**(orange), **Offline**(grey) and are part of *avatar*.
- All avatar occurrences are covered with the user status. Due to UI friendliness, some of them have status disabled using `hide_status: true` (check the list of `.html` files below)
- Chat bots are **always** set to Active.
- Statuses are set based on user activites, statuses **can't be set manually**.

### Important!
In order this feature to work in `dev` mode caching **MUST** be set for local development via: `rails dev:cache`, as described in readme of the project.

#### As for the code:
##### CSS
  - `app/assets/stylesheets/utilities.css` - classes for new user status feature
##### Channel
  - `app/channels/user_status_channel.rb` - new channel added
    - Receives updates from users, as they change their statuses i.e. activities
    - Store each status per user in cache
    - Broadcast the whole hash with **all** of the statues of all users from cache
#### Helpers
  - `app/helpers/application_helper.rb` - 2 methods added
  - `app/helpers/users/avatars_helper.rb`
    - Modified avatar helper to include appropriate HTML div element, css, data-* controllers actions values, etc.
    - At some pages large avatar is displayed, hence the logic to increase status element accordingly
    - `user_status_tag` - renders *div* for the status, and it has been set on the app level, so **wherever the avatar is rendered this method is invoked**. Previously there was part avatar_tag part HTML usage for displaying the avatars.
#### Stimulus controllers added
  - `app/javascript/controllers/user_status_controller.js`
    - Inspired by `app/javascript/controllers/refresh_room_controller.js`
    - Set on the **body** i.e. **application level**, and is practilally reposnible for listening the document events 
    `data-action="visibilitychange@document->user-status#visibilityChanged"`
    The timer values are taken from existing controller `app/javascript/controllers/refresh_room_controller.js`
      ```
      const OFFLINE_AFTER_DISCONNECTED_TIMEOUT = 5_000
      const REFRESH_AFTER_HIDDEN_TIMEOUT = 60_000.
      ```
    - Upon timeout, event is sent via `UserStatusChannel` (Active or Away).
    - If the user is disconnected (closed tab, logout, etc.) channel itself `app/channels/user_status_channel.rb` treats it as offline event and sends the updated hash.
      - Note that `#setStatusOffline` is present for the sake of future use, if any, but offline status is detected by BE when the socket is closed.
    - This controller is responsible only for sending status to the BE.
  - `app/javascript/controllers/user_status_avatar_controller.js`
    - This controller is responsible **only for updating** the status elements based on the user ID and status that is received.
    - Each status update by user_status_controller.js **triggers broadcast** with the data of all users that have been registered, and this controller sets the status based on the user ID and the status value.
  - This is handled in `received` handler of this Controller.
#### HTML
  - `app/views/layouts/application.html.erb` - set scope for `app/javascript/controllers/user_status_controller.js`
  - ##### Avatar locations update list
    - `app/views/messages/boosts/_boost.html.erb` - status disabled using `hide_status: true` since it wasn't UI friendly
    - `app/views/messages/boosts/new.html.erb` - status disabled using `hide_status: true` since it wasn't UI friendly
    - `app/views/rooms/directs/edit.html.erb` - here we have large avatar displayed
    - `app/views/users/_mention.html.erb` - status disabled using `hide_status: true` since it wasn't UI friendly
    - `app/views/users/sidebars/rooms/_direct.html.erb` - avatars in the sidebar - top
    - `app/views/users/sidebars/show.html.erb` - **current** user's avatar in sidebar - bottom

### Final notes
Ideally user presence should:
- Have more statuses e.g. Busy, Out of Office, DND (do not disturb) etc.
- Should be set manually
- Should have certain effect on the notifications e.g. DND status should disable any notification etc.

But to implement all that, firstly small step is required :).

Thanks.