### PR TITLE
[Logout localhost fix] - fixing an error for logout process on localhost fix

### DIFF
--- a/app/javascript/controllers/sessions_controller.js
+++ b/app/javascript/controllers/sessions_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
 
   async #unsubscribeFromWebPush() {
     if ("serviceWorker" in navigator) {
-      const registration = await navigator.serviceWorker.getRegistration(window.location.host)
+      const registration = await navigator.serviceWorker.getRegistration(window.location.origin)
 
       if (registration) {
         const subscription = await registration.pushManager.getSubscription()


### PR DESCRIPTION
If you want to test logout functionality, you get an error:
```
Uncaught (in promise) SecurityError: Failed to get a ServiceWorkerRegistration: The origin of the provided documentURL ('null') does not match the current origin ('http://localhost:3000').
logout @ sessions_controller-9966caf9.js:9
await in logout
invokeWithEvent @ controller.ts:28
handleEvent @ controller.ts:28
handleEvent @ controller.ts:28
```

The fix for this is same as for PR #49 .