### PR TITLE
Add dir="auto" to messages for rtl lang support

### DIFF
--- a/app/views/messages/_presentation.html.erb
+++ b/app/views/messages/_presentation.html.erb
@@ -1,3 +1,3 @@
-<div id="<%= dom_id(message, :presentation) %>" data-reply-target="body" data-messages-target="body">
+<div id="<%= dom_id(message, :presentation) %>" dir="auto" data-reply-target="body" data-messages-target="body">
   <%= message_presentation(message) %>
 </div>


### PR DESCRIPTION
### Add auto direction for message content
- **What:** Set `dir="auto"` on the message presentation wrapper so each message renders LTR/RTL based on its first strongly directional character.
- **Why:** Improve readability for RTL languages (e.g., Arabic, Hebrew) without affecting LTR content.
- **Where:** `app/views/messages/_presentation.html.erb`
- **Impact:** Visual-only; no backend changes. Widely supported across modern browsers.
- **Testing:**
  - Post messages in Arabic and English; verify Arabic messages render RTL and English remains LTR.
  - Mixed content still displays correctly within each message.
- **Notes:** No tests updated; markup change only.

### Example
- **First message:** only English
- **Second message:** English + Arabic + English
- **Third message:** Arabic + English + Arabic

Only third one is affected where the direction is automatically set to RTL

#### Before:
<img width="375" height="232" alt="image" src="https://github.com/user-attachments/assets/f54aa9a0-bc74-4ad8-848b-42121b1dccf5" />

#### After:
<img width="375" height="232" alt="image" src="https://github.com/user-attachments/assets/c7644b49-165a-4b11-8d82-d54edc616b45" />
