### PR TITLE
Serve avatar and logo variants through Active Storage

### DIFF
--- a/app/controllers/accounts/logos_controller.rb
+++ b/app/controllers/accounts/logos_controller.rb
@@ -9,8 +9,7 @@ class Accounts::LogosController < ApplicationController
       expires_in 5.minutes, public: true, stale_while_revalidate: 1.week
 
       if Current.account&.logo&.attached?
-        logo = Current.account.logo.variant(logo_variant).processed
-        send_png_file ActiveStorage::Blob.service.path_for(logo.key)
+        send_blob_stream Current.account.logo.variant(logo_variant).processed, disposition: :inline
       else
         send_stock_icon
       end

--- a/app/controllers/users/avatars_controller.rb
+++ b/app/controllers/users/avatars_controller.rb
@@ -10,8 +10,7 @@ class Users::AvatarsController < ApplicationController
       expires_in 30.minutes, public: true, stale_while_revalidate: 1.week
 
       if @user.avatar.attached?
-        avatar_variant = @user.avatar.variant(SQUARE_WEBP_VARIANT).processed
-        send_webp_blob_file avatar_variant.key
+        send_webp_blob @user.avatar.variant(SQUARE_WEBP_VARIANT).processed
       elsif @user.bot?
         render_default_bot
       else
@@ -28,8 +27,8 @@ class Users::AvatarsController < ApplicationController
   private
     SQUARE_WEBP_VARIANT = { resize_to_limit: [ 512, 512 ], format: :webp }
 
-    def send_webp_blob_file(key)
-      send_file ActiveStorage::Blob.service.path_for(key), content_type: "image/webp", disposition: :inline
+    def send_webp_blob(blob)
+      send_blob_stream blob, disposition: :inline
     end
 
     def render_default_bot

--- a/app/controllers/users/avatars_controller.rb
+++ b/app/controllers/users/avatars_controller.rb
@@ -10,7 +10,7 @@ class Users::AvatarsController < ApplicationController
       expires_in 30.minutes, public: true, stale_while_revalidate: 1.week
 
       if @user.avatar.attached?
-        send_webp_blob @user.avatar.variant(SQUARE_WEBP_VARIANT).processed
+        send_blob_stream @user.avatar.variant(SQUARE_WEBP_VARIANT).processed, disposition: :inline
       elsif @user.bot?
         render_default_bot
       else
@@ -26,10 +26,6 @@ class Users::AvatarsController < ApplicationController
 
   private
     SQUARE_WEBP_VARIANT = { resize_to_limit: [ 512, 512 ], format: :webp }
-
-    def send_webp_blob(blob)
-      send_blob_stream blob, disposition: :inline
-    end
 
     def render_default_bot
       send_file Rails.root.join("app/assets/images/default-bot-avatar.svg"), content_type: "image/svg+xml", disposition: :inline

--- a/test/controllers/accounts/logos_controller_test.rb
+++ b/test/controllers/accounts/logos_controller_test.rb
@@ -23,6 +23,15 @@ class Accounts::LogosControllerTest < ActionDispatch::IntegrationTest
     assert_valid_png_response size: 512
   end
 
+  test "show custom when active storage service has no path_for" do
+    with_pathless_active_storage_service do
+      accounts(:signal).update! logo: fixture_file_upload("moon.jpg", "image/jpeg")
+
+      get account_logo_url
+      assert_valid_png_response size: 512
+    end
+  end
+
   test "show custom small size" do
     accounts(:signal).update! logo: fixture_file_upload("moon.jpg", "image/jpeg")
 

--- a/test/controllers/users/avatars_controller_test.rb
+++ b/test/controllers/users/avatars_controller_test.rb
@@ -18,6 +18,17 @@ class Users::AvatarsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "image/webp", @response.content_type
   end
 
+  test "show image when active storage service has no path_for" do
+    with_pathless_active_storage_service do
+      users(:kevin).update! avatar: fixture_file_upload("moon.jpg", "image/jpeg")
+
+      get user_avatar_url(users(:kevin).avatar_token)
+
+      assert_response :success
+      assert_equal "image/webp", @response.content_type
+    end
+  end
+
   test "show image with invalid token responds 404" do
     get user_avatar_url("not-a-valid-token")
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  include SessionTestHelper, MentionTestHelper, TurboTestHelper
+  include SessionTestHelper, MentionTestHelper, TurboTestHelper, ActiveStorageServiceTestHelper
 
   setup do
     ActionCable.server.pubsub.clear

--- a/test/test_helpers/active_storage_service_test_helper.rb
+++ b/test/test_helpers/active_storage_service_test_helper.rb
@@ -1,0 +1,89 @@
+class PathlessActiveStorageTestService < ActiveStorage::Service
+  attr_reader :delegate_service
+
+  def initialize(delegate_service:)
+    @delegate_service = delegate_service
+  end
+
+  def upload(...)
+    delegate_service.upload(...)
+  end
+
+  def update_metadata(...)
+    delegate_service.update_metadata(...)
+  end
+
+  def download(...)
+    delegate_service.download(...)
+  end
+
+  def download_chunk(...)
+    delegate_service.download_chunk(...)
+  end
+
+  def open(...)
+    delegate_service.open(...)
+  end
+
+  def compose(...)
+    delegate_service.compose(...)
+  end
+
+  def delete(...)
+    delegate_service.delete(...)
+  end
+
+  def delete_prefixed(...)
+    delegate_service.delete_prefixed(...)
+  end
+
+  def exist?(...)
+    delegate_service.exist?(...)
+  end
+
+  def url(...)
+    delegate_service.url(...)
+  end
+
+  def url_for_direct_upload(...)
+    delegate_service.url_for_direct_upload(...)
+  end
+
+  def headers_for_direct_upload(...)
+    delegate_service.headers_for_direct_upload(...)
+  end
+end
+
+module ActiveStorageServiceTestHelper
+  class AdditionalActiveStorageServices
+    def initialize(delegate_registry:, extra_services:)
+      @delegate_registry = delegate_registry
+      @extra_services = extra_services.transform_keys(&:to_sym)
+    end
+
+    def fetch(name, &block)
+      @extra_services.fetch(name.to_sym) do
+        @delegate_registry.fetch(name, &block)
+      end
+    end
+  end
+
+  def with_pathless_active_storage_service
+    original_service = ActiveStorage::Blob.service
+    original_services = ActiveStorage::Blob.services
+
+    pathless_service = PathlessActiveStorageTestService.new(delegate_service: original_services.fetch(:test))
+    pathless_service.name = :pathless_test
+
+    ActiveStorage::Blob.services = AdditionalActiveStorageServices.new(
+      delegate_registry: original_services,
+      extra_services: { pathless_test: pathless_service }
+    )
+    ActiveStorage::Blob.service = pathless_service
+
+    yield
+  ensure
+    ActiveStorage::Blob.service = original_service
+    ActiveStorage::Blob.services = original_services
+  end
+end


### PR DESCRIPTION
Fixes #186.

## Summary

This PR removes a `DiskService`-specific assumption from the avatar and account logo serving controllers.

Upstream Campfire currently hard-codes production Active Storage to `:local`, so this PR does not claim to enable or officially support S3-backed storage on vanilla `main`. I found the failure while running a self-hosted deployment that made Active Storage env-selectable and configured it for S3/MinIO.

In that setup, uploads and downloads worked, but the follow-up avatar/logo image requests failed because these controllers called `ActiveStorage::Blob.service.path_for(...)`. That method returns a local filesystem path and exists on `DiskService`, but pathless services such as `ActiveStorage::Service::S3Service` expose blobs through Active Storage's download/streaming APIs instead.

## Change

The avatar and account logo controllers now stream the processed Active Storage representation through `send_blob_stream` instead of resolving the variant key to a local file path.

That keeps the current local-disk behavior working while avoiding a direct dependency on `DiskService` internals.

## Scope

- Does not add S3 configuration to upstream Campfire.
- Does not change the default local-disk deployment behavior.
- Keeps this as service-agnostic hardening for code that is already using Active Storage.
- Adds regression coverage with a test-only pathless Active Storage service, so the tests guard the intended behavior without requiring upstream to support S3 today.

## Verification

- Reproduced the `NoMethodError` in a live self-hosted deployment using S3-backed Active Storage.
- Confirmed uploads and downloads succeeded before the controller failed while serving the processed representation.
- Verified the deployed fix resolves the broken avatar rendering path.
- Added controller regressions for avatars and account logos using a test-only Active Storage service that behaves like a pathless remote service.
- Ran:
  - `LD_LIBRARY_PATH=$(brew --prefix vips)/lib REDIS_URL=redis://localhost:6379/0 bundle exec ruby -Itest test/controllers/users/avatars_controller_test.rb`
  - `LD_LIBRARY_PATH=$(brew --prefix vips)/lib REDIS_URL=redis://localhost:6379/0 bundle exec ruby -Itest test/controllers/accounts/logos_controller_test.rb`
