### PR TITLE
Fix crash when user has 20+ direct conversations

### DIFF
--- a/app/controllers/users/sidebars_controller.rb
+++ b/app/controllers/users/sidebars_controller.rb
@@ -16,7 +16,7 @@ class Users::SidebarsController < ApplicationController
 
     def find_direct_placeholder_users
       exclude_user_ids = user_ids_already_in_direct_rooms_with_current_user.including(Current.user.id)
-      User.active.where.not(id: exclude_user_ids).order(:created_at).limit(DIRECT_PLACEHOLDERS - exclude_user_ids.count)
+      User.active.where.not(id: exclude_user_ids).order(:created_at).limit([DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0].max)
     end
 
     def user_ids_already_in_direct_rooms_with_current_user


### PR DESCRIPTION
## Problem

`find_direct_placeholder_users` in `Users::SidebarsController` passes a negative value to `.limit()` when a user has direct rooms with 20 or more unique participants. PostgreSQL raises `LIMIT must not be negative`, crashing the sidebar controller. Since the sidebar is loaded via a Turbo Frame on every page, this makes the entire application unusable for that user — "Content missing" on every page, every browser, every device.

## Fix

Clamp the limit to a minimum of zero so `limit(0)` returns an empty result set instead of raising. One-line change.

See https://github.com/basecamp/once-campfire/discussions/191
