### PR TITLE
feat: Add OpenID Connect (OIDC) support for Single Sign-On (SSO) integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ app/assets/builds/*
 
 # Ignore our exported zipfiles
 /*.zip
+/.idea

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,11 @@ gem "image_processing", ">= 1.2"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# SSO / External Authentication
+gem "omniauth", "~> 2.1"
+gem "omniauth-rails_csrf_protection", "~> 1.0"
+gem "omniauth_openid_connect", "~> 0.8"
+
 # Other
 gem "bcrypt"
 gem "web-push"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,11 +132,14 @@ GEM
       railties
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.3)
+    attr_required (1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
+    bindata (2.5.1)
     brakeman (8.0.4)
       racc
     builder (3.3.0)
@@ -161,17 +164,32 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.3)
+    email_validator (2.2.4)
+      activemodel
     erb (6.0.0)
     erubi (1.13.1)
     faker (3.5.2)
       i18n (>= 1.8.11, < 2)
-    ffi (1.17.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     geared_pagination (1.2.0)
       activesupport (>= 5.0)
       addressable (>= 2.5.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.2.0)
+    hashie (5.1.0)
+      logger
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -186,6 +204,13 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.13.2)
+    json-jwt (1.17.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     jwt (3.1.2)
       base64
     kredis (1.8.0)
@@ -209,7 +234,6 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.26.2)
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
@@ -217,6 +241,8 @@ GEM
     multi_json (1.17.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
     net-imap (0.5.12)
@@ -229,9 +255,38 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.8.0)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.3.1)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
     openssl (3.3.0)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -253,6 +308,13 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.4)
+    rack-oauth2 (2.3.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -357,11 +419,18 @@ GEM
       rack-protection (= 4.1.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    sqlite3 (2.7.3)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.7.3-aarch64-linux-gnu)
+    sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86_64-darwin)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.8)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.4.0)
     thruster (0.1.15-aarch64-linux)
     thruster (0.1.15-arm64-darwin)
@@ -377,9 +446,16 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     web-push (3.0.2)
       jwt (~> 3.0)
       openssl (~> 3.0)
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -413,6 +489,9 @@ DEPENDENCIES
   kredis
   mocha
   net-http-persistent
+  omniauth (~> 2.1)
+  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth_openid_connect (~> 0.8)
   ostruct
   platform_agent
   propshaft!

--- a/README.md
+++ b/README.md
@@ -29,6 +29,43 @@ To configure additional features, you can set the following environment variable
 - `SENTRY_DSN` - to enable error reporting to sentry in production, supply your
   DSN here
 
+### Single Sign-On (SSO)
+
+Campfire supports SSO via OpenID Connect (OIDC), allowing integration with
+identity providers such as Keycloak, Okta, Azure AD, and Google Workspace.
+SSO is entirely optional — when no SSO environment variables are set, the login
+page shows only the standard email/password form.
+
+Both SSO and password authentication can coexist. Users who first registered with
+a password will have their account automatically linked when they sign in via SSO
+(matched by email address). New users signing in via SSO for the first time are
+created automatically and do not need a join code.
+
+To disable password-based registration (so new users can only join via SSO), set:
+
+- `DISABLE_PASSWORD_REGISTRATION=true` - disables the join code registration
+  page and hides the invite link from the admin panel. Existing users can still
+  sign in with their password.
+
+**OIDC configuration (multiple providers):**
+
+- `OIDC_PROVIDERS` - comma-separated provider keys (for example: `google,github,keycloak`)
+- For each key, define:
+  - `OIDC_<KEY>_ISSUER` - issuer URL
+  - `OIDC_<KEY>_CLIENT_ID` - client ID
+  - `OIDC_<KEY>_CLIENT_SECRET` - client secret
+  - `OIDC_<KEY>_REDIRECT_URI` - callback URL (for example `https://chat.example.com/auth/oidc_google/callback`)
+- Optional per provider:
+  - `OIDC_<KEY>_PROVIDER_NAME` - label shown on the sign-in button (defaults to titleized key)
+  - `OIDC_<KEY>_SCOPE` - scopes separated by spaces or commas (defaults to `openid email profile`)
+  - `OIDC_<KEY>_CLIENT_AUTH_METHOD` - client auth method (defaults to `basic`)
+  - `OIDC_<KEY>_END_SESSION_ENDPOINT` - explicit RP-initiated logout endpoint (otherwise discovered from issuer metadata - `${OIDC_<KEY>_ISSUER}/.well-known/openid-configuration`)
+
+Provider keys must use lowercase letters, numbers, and underscores.
+When a user signs out from Campfire, the app also attempts OIDC RP-initiated
+logout with the provider used for that login session and includes
+`id_token_hint` when available.
+
 For example:
 
     docker build -t campfire .
@@ -41,6 +78,27 @@ For example:
       --env VAPID_PUBLIC_KEY=$YOUR_PUBLIC_KEY \
       --env VAPID_PRIVATE_KEY=$YOUR_PRIVATE_KEY \
       --env TLS_DOMAIN=chat.example.com \
+      campfire
+
+With OIDC SSO enabled:
+
+    docker run \
+      --publish 80:80 --publish 443:443 \
+      --restart unless-stopped \
+      --volume campfire:/rails/storage \
+      --env SECRET_KEY_BASE=$YOUR_SECRET_KEY_BASE \
+      --env TLS_DOMAIN=chat.example.com \
+      --env OIDC_PROVIDERS=google,keycloak \
+      --env OIDC_GOOGLE_ISSUER=https://accounts.google.com \
+      --env OIDC_GOOGLE_CLIENT_ID=$YOUR_GOOGLE_CLIENT_ID \
+      --env OIDC_GOOGLE_CLIENT_SECRET=$YOUR_GOOGLE_CLIENT_SECRET \
+      --env OIDC_GOOGLE_REDIRECT_URI=https://chat.example.com/auth/oidc_google/callback \
+      --env OIDC_GOOGLE_PROVIDER_NAME=Google \
+      --env OIDC_KEYCLOAK_ISSUER=https://keycloak.example.com/realms/campfire \
+      --env OIDC_KEYCLOAK_CLIENT_ID=campfire \
+      --env OIDC_KEYCLOAK_CLIENT_SECRET=$YOUR_KEYCLOAK_CLIENT_SECRET \
+      --env OIDC_KEYCLOAK_REDIRECT_URI=https://chat.example.com/auth/oidc_keycloak/callback \
+      --env OIDC_KEYCLOAK_PROVIDER_NAME=Keycloak \
       campfire
 
 ## Running in development

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -56,8 +56,13 @@ module Authentication
       redirect_to root_url if signed_in?
     end
 
-    def start_new_session_for(user)
-      user.sessions.start!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
+    def start_new_session_for(user, sso_provider: nil, oidc_id_token: nil)
+      user.sessions.start!(
+        user_agent: request.user_agent,
+        ip_address: request.remote_ip,
+        sso_provider: sso_provider,
+        oidc_id_token: oidc_id_token
+      ).tap do |session|
         authenticated_as session
       end
     end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -20,11 +20,31 @@ class RoomsController < ApplicationController
 
   private
     def set_room
-      if room = Current.user.rooms.find_by(id: params[:room_id] || params[:id])
+      if room = Current.user.rooms.find_by(id: requested_room_id) || invited_room_for_current_user
         @room = room
       else
         redirect_to root_url, alert: "Room not found or inaccessible"
       end
+    end
+
+    def requested_room_id
+      params[:room_id] || params[:id]
+    end
+
+    def invited_room_for_current_user
+      return unless action_name == "show"
+
+      invite_token = params[:invite].to_s.presence
+      return if invite_token.blank?
+
+      room = Room.find_by_sso_invite_token(invite_token)
+      return unless room&.id == requested_room_id.to_i
+
+      Membership.create_or_find_by!(room:, user: Current.user) do |membership|
+        membership.involvement = room.default_involvement
+      end
+
+      room
     end
 
     def ensure_can_administer

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,15 +11,24 @@ class SessionsController < ApplicationController
     if user = User.active.authenticate_by(email_address: params[:email_address], password: params[:password])
       start_new_session_for user
       redirect_to post_authenticating_url
+    elsif helpers.sso_enabled? && User.active.find_by(email_address: params[:email_address])&.sso?
+      flash.now[:alert] = "This account uses Single Sign-On."
+      render :new, status: :unauthorized
     else
       render_rejection :unauthorized
     end
   end
 
   def destroy
+    oidc_logout_url = OidcLogout.logout_url_for(
+      strategy: Current.session&.sso_provider,
+      id_token_hint: Current.session&.oidc_id_token,
+      post_logout_redirect_uri: root_url
+    )
+
     remove_push_subscription
     terminate_current_session
-    redirect_to root_url
+    redirect_to oidc_logout_url || root_url, allow_other_host: oidc_logout_url.present?
   end
 
   private

--- a/app/controllers/sso_sessions_controller.rb
+++ b/app/controllers/sso_sessions_controller.rb
@@ -1,0 +1,74 @@
+class SsoSessionsController < ApplicationController
+  allow_unauthenticated_access
+
+  def create
+    auth = request.env["omniauth.auth"]
+
+    if auth.blank?
+      redirect_to new_session_url, alert: "Authentication failed."
+      return
+    end
+
+    user = SsoAuthentication.find_or_create_user_from(auth)
+
+    if user.active?
+      grant_membership_to_invited_room(user) if user.sessions.none?
+      start_new_session_for(
+        user,
+        sso_provider: auth.provider.to_s,
+        oidc_id_token: extract_oidc_id_token(auth)
+      )
+      redirect_to post_authenticating_url
+    else
+      redirect_to new_session_url, alert: "Your account has been deactivated."
+    end
+  rescue SsoAuthentication::Error => e
+    Rails.logger.error "SSO authentication failed: #{e.message}"
+    redirect_to new_session_url, alert: "Authentication failed."
+  end
+
+  def failure
+    strategy = params[:strategy].to_s.presence&.upcase
+    detail   = params[:detail].to_s.presence || params[:message].to_s.humanize
+    detail   = detail.gsub(/\s+/, " ").strip.first(280)
+
+    message = [ "SSO authentication failed", strategy&.then { "(#{_1})" }, detail.presence&.then { "— #{_1}" } ].compact.join(" ") + "."
+
+    Rails.logger.error message
+    redirect_to new_session_url, alert: message
+  end
+
+  private
+    def grant_membership_to_invited_room(user)
+      room = invited_room_from_return_url
+      return unless room
+
+      Membership.create_or_find_by!(room:, user:) do |membership|
+        membership.involvement = room.default_involvement
+      end
+    end
+
+    def invited_room_from_return_url
+      return_to = session[:return_to_after_authenticating].to_s
+      return if return_to.blank?
+
+      uri = URI.parse(return_to)
+      room_id = uri.path[%r{\A/rooms/(?<id>\d+)(?:/|$)}, :id]&.to_i
+      invite_token = Rack::Utils.parse_nested_query(uri.query.to_s)["invite"].to_s.presence
+
+      return if room_id.blank? || invite_token.blank?
+
+      room = Room.find_by_sso_invite_token(invite_token)
+      room if room&.id == room_id
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def extract_oidc_id_token(auth)
+      raw_token = auth.dig(:credentials, :id_token) ||
+        auth.dig(:extra, :id_token) ||
+        auth.dig(:extra, :raw_info, :id_token)
+
+      raw_token.to_s.strip.presence
+    end
+end

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -17,7 +17,13 @@ class Users::ProfilesController < ApplicationController
     end
 
     def user_params
-      params.require(:user).permit(:name, :avatar, :email_address, :password, :bio).compact
+      permitted = params.require(:user).permit(:name, :avatar, :email_address, :password, :bio).compact
+      if @user.sso?
+        permitted.delete(:password) unless helpers.password_registration_enabled?
+        permitted.delete(:name)
+        permitted.delete(:email_address)
+      end
+      permitted
     end
 
     def update_notice

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   require_unauthenticated_access only: %i[ new create ]
 
   before_action :set_user, only: :show
+  before_action :ensure_password_registration_enabled, only: %i[ new create ]
   before_action :verify_join_code, only: %i[ new create ]
 
   def new
@@ -22,6 +23,12 @@ class UsersController < ApplicationController
   private
     def set_user
       @user = User.find(params[:id])
+    end
+
+    def ensure_password_registration_enabled
+      unless helpers.password_registration_enabled?
+        redirect_to new_session_url, alert: "Sign in with your SSO provider to join."
+      end
     end
 
     def verify_join_code

--- a/app/helpers/sso_helper.rb
+++ b/app/helpers/sso_helper.rb
@@ -12,6 +12,6 @@ module SsoHelper
   end
 
   def password_registration_enabled?
-    !ENV["DISABLE_PASSWORD_REGISTRATION"].in?(%w[ true 1 yes ])
+    !ENV["DISABLE_PASSWORD_REGISTRATION"].to_s.downcase.in?(%w[ true 1 yes ])
   end
 end

--- a/app/helpers/sso_helper.rb
+++ b/app/helpers/sso_helper.rb
@@ -1,0 +1,17 @@
+module SsoHelper
+  def sso_enabled?
+    oidc_enabled?
+  end
+
+  def oidc_providers
+    @oidc_providers ||= OidcConfiguration.providers
+  end
+
+  def oidc_enabled?
+    oidc_providers.any?
+  end
+
+  def password_registration_enabled?
+    !ENV["DISABLE_PASSWORD_REGISTRATION"].in?(%w[ true 1 yes ])
+  end
+end

--- a/app/models/oidc_configuration.rb
+++ b/app/models/oidc_configuration.rb
@@ -1,0 +1,106 @@
+require "uri"
+
+class OidcConfiguration
+  PROVIDERS_ENV_KEY = "OIDC_PROVIDERS".freeze
+  PROVIDER_KEY_FORMAT = /\A[a-z][a-z0-9_]*\z/.freeze
+  REQUIRED_KEYS = %w[ISSUER CLIENT_ID CLIENT_SECRET REDIRECT_URI].freeze
+  DEFAULT_SCOPE = %w[openid email profile].freeze
+  DEFAULT_CLIENT_AUTH_METHOD = "basic".freeze
+
+  class << self
+    def providers(env: ENV)
+      provider_keys(env:)
+        .map { build_provider(_1, env:) }
+        .tap { validate_unique_strategy_names!(_1) }
+    end
+
+    def strategy_names(env: ENV)
+      providers(env:).map { _1[:strategy] }
+    end
+
+    def provider_for_strategy(strategy, env: ENV)
+      strategy_name = strategy.to_s
+      return if strategy_name.blank?
+
+      providers(env:).find { _1.fetch(:strategy) == strategy_name }
+    end
+
+    private
+      def provider_keys(env:)
+        keys = env.fetch(PROVIDERS_ENV_KEY, "")
+          .split(",")
+          .map { _1.strip.downcase }
+          .reject(&:blank?)
+
+        duplicates = keys.tally.select { _2 > 1 }.keys
+        if duplicates.any?
+          raise ArgumentError, "Duplicate OIDC provider keys in #{PROVIDERS_ENV_KEY}: #{duplicates.join(', ')}"
+        end
+
+        invalid = keys.reject { PROVIDER_KEY_FORMAT.match?(_1) }
+        if invalid.any?
+          raise ArgumentError, "Invalid OIDC provider key(s): #{invalid.join(', ')}. Use lowercase letters, numbers, and underscores."
+        end
+
+        keys
+      end
+
+      def build_provider(key, env:)
+        uppercase_key = key.upcase
+        required_config = REQUIRED_KEYS.to_h do |config_key|
+          [ config_key.downcase.to_sym, read_required(env:, provider_key: uppercase_key, config_key:) ]
+        end
+
+        strategy = strategy_from_redirect_uri(required_config.fetch(:redirect_uri))
+
+        {
+          key:,
+          strategy:,
+          display_name: provider_display_name(env:, uppercase_key:, key:),
+          scope: parse_scope(env["OIDC_#{uppercase_key}_SCOPE"]),
+          client_auth_method: env["OIDC_#{uppercase_key}_CLIENT_AUTH_METHOD"].presence || DEFAULT_CLIENT_AUTH_METHOD,
+          end_session_endpoint: env["OIDC_#{uppercase_key}_END_SESSION_ENDPOINT"].presence
+        }.merge(required_config)
+      end
+
+      def provider_display_name(env:, uppercase_key:, key:)
+        env["OIDC_#{uppercase_key}_PROVIDER_NAME"].presence ||
+          env["OIDC_#{uppercase_key}_DISPLAY_NAME"].presence ||
+          key.tr("_", " ").titleize
+      end
+
+      def strategy_from_redirect_uri(redirect_uri)
+        uri = URI.parse(redirect_uri)
+        strategy = uri.path[%r{\A/auth/(?<provider>[a-z0-9_]+)/callback\z}, :provider]
+
+        if strategy.blank?
+          raise ArgumentError, "OIDC redirect URI must use /auth/<provider>/callback (got #{redirect_uri.inspect})"
+        end
+
+        strategy
+      rescue URI::InvalidURIError => e
+        raise ArgumentError, "OIDC redirect URI is invalid: #{e.message}"
+      end
+
+      def validate_unique_strategy_names!(providers)
+        duplicates = providers.map { _1.fetch(:strategy) }.tally.select { _2 > 1 }.keys
+        return if duplicates.empty?
+
+        raise ArgumentError, "OIDC redirect URIs resolve to duplicate strategy names: #{duplicates.join(', ')}"
+      end
+
+      def read_required(env:, provider_key:, config_key:)
+        env_key = "OIDC_#{provider_key}_#{config_key}"
+        value = env[env_key].to_s.strip
+
+        raise ArgumentError, "#{env_key} is required when #{PROVIDERS_ENV_KEY} includes '#{provider_key.downcase}'" if value.blank?
+
+        value
+      end
+
+      def parse_scope(raw_scope)
+        parsed_scope = raw_scope.to_s.split(/[\s,]+/).reject(&:blank?)
+        parsed_scope.presence || DEFAULT_SCOPE
+      end
+  end
+end

--- a/app/models/oidc_logout.rb
+++ b/app/models/oidc_logout.rb
@@ -5,13 +5,14 @@ require "uri"
 class OidcLogout
   DISCOVERY_DOCUMENT = ".well-known/openid-configuration".freeze
   REQUEST_TIMEOUT = 2.seconds
+  DISCOVERY_CACHE_EXPIRES_IN = 15.minutes
 
   class << self
     def logout_url_for(strategy:, post_logout_redirect_uri:, id_token_hint: nil, env: ENV)
       provider = OidcConfiguration.provider_for_strategy(strategy, env:)
       return if provider.blank?
 
-      end_session_endpoint = provider.fetch(:end_session_endpoint).presence || discover_end_session_endpoint(provider.fetch(:issuer))
+      end_session_endpoint = find_end_session_endpoint(provider)
       return if end_session_endpoint.blank?
 
       build_logout_url(
@@ -26,12 +27,48 @@ class OidcLogout
     end
 
     private
+      def find_end_session_endpoint(provider)
+        issuer = provider.fetch(:issuer)
+        endpoint = provider.fetch(:end_session_endpoint).presence || discover_end_session_endpoint(issuer)
+        return if endpoint.blank?
+
+        validate_end_session_endpoint(endpoint, issuer:, configured: provider.fetch(:end_session_endpoint).present?)
+      end
+
+      def validate_end_session_endpoint(endpoint, issuer:, configured:)
+        endpoint_uri = URI.parse(endpoint)
+
+        unless endpoint_uri.is_a?(URI::HTTPS) && endpoint_uri.host.present?
+          Rails.logger.warn("OIDC logout skipped because end-session endpoint is not a valid HTTPS URL: #{endpoint.inspect}")
+          return nil
+        end
+
+        return endpoint if configured
+
+        issuer_uri = URI.parse(issuer)
+        return endpoint if issuer_uri.host == endpoint_uri.host
+
+        Rails.logger.warn(
+          "OIDC logout skipped because discovered end-session host #{endpoint_uri.host.inspect} does not match issuer host #{issuer_uri.host.inspect}"
+        )
+        nil
+      rescue URI::InvalidURIError => e
+        Rails.logger.warn("Invalid OIDC endpoint/issuer URL while resolving logout endpoint: #{e.message}")
+        nil
+      end
+
       def discover_end_session_endpoint(issuer)
         metadata = provider_metadata(issuer)
         metadata["end_session_endpoint"].presence
       end
 
       def provider_metadata(issuer)
+        Rails.cache.fetch(discovery_cache_key(issuer), expires_in: DISCOVERY_CACHE_EXPIRES_IN) do
+          load_provider_metadata(issuer)
+        end
+      end
+
+      def load_provider_metadata(issuer)
         uri = discovery_uri(issuer)
         response = http_get(uri)
         return {} unless response.is_a?(Net::HTTPSuccess)
@@ -40,6 +77,10 @@ class OidcLogout
       rescue JSON::ParserError, URI::InvalidURIError, SocketError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout => e
         Rails.logger.warn("Failed to load OIDC metadata for issuer #{issuer.inspect}: #{e.class}: #{e.message}")
         {}
+      end
+
+      def discovery_cache_key(issuer)
+        "oidc:provider_metadata:#{issuer}"
       end
 
       def discovery_uri(issuer)

--- a/app/models/oidc_logout.rb
+++ b/app/models/oidc_logout.rb
@@ -1,0 +1,73 @@
+require "json"
+require "net/http"
+require "uri"
+
+class OidcLogout
+  DISCOVERY_DOCUMENT = ".well-known/openid-configuration".freeze
+  REQUEST_TIMEOUT = 2.seconds
+
+  class << self
+    def logout_url_for(strategy:, post_logout_redirect_uri:, id_token_hint: nil, env: ENV)
+      provider = OidcConfiguration.provider_for_strategy(strategy, env:)
+      return if provider.blank?
+
+      end_session_endpoint = provider.fetch(:end_session_endpoint).presence || discover_end_session_endpoint(provider.fetch(:issuer))
+      return if end_session_endpoint.blank?
+
+      build_logout_url(
+        end_session_endpoint: end_session_endpoint,
+        client_id: provider.fetch(:client_id),
+        post_logout_redirect_uri: post_logout_redirect_uri,
+        id_token_hint: id_token_hint
+      )
+    rescue ArgumentError => e
+      Rails.logger.warn("OIDC logout skipped for strategy #{strategy.inspect}: #{e.message}")
+      nil
+    end
+
+    private
+      def discover_end_session_endpoint(issuer)
+        metadata = provider_metadata(issuer)
+        metadata["end_session_endpoint"].presence
+      end
+
+      def provider_metadata(issuer)
+        uri = discovery_uri(issuer)
+        response = http_get(uri)
+        return {} unless response.is_a?(Net::HTTPSuccess)
+
+        JSON.parse(response.body)
+      rescue JSON::ParserError, URI::InvalidURIError, SocketError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout => e
+        Rails.logger.warn("Failed to load OIDC metadata for issuer #{issuer.inspect}: #{e.class}: #{e.message}")
+        {}
+      end
+
+      def discovery_uri(issuer)
+        uri = URI.parse(issuer)
+        issuer_path = uri.path.to_s.delete_suffix("/")
+        uri.path = "#{issuer_path}/#{DISCOVERY_DOCUMENT}"
+        uri.query = nil
+        uri.fragment = nil
+        uri
+      end
+
+      def http_get(uri)
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: REQUEST_TIMEOUT, read_timeout: REQUEST_TIMEOUT) do |http|
+          http.get(uri.request_uri)
+        end
+      end
+
+      def build_logout_url(end_session_endpoint:, client_id:, post_logout_redirect_uri:, id_token_hint:)
+        uri = URI.parse(end_session_endpoint)
+        params = Rack::Utils.parse_nested_query(uri.query.to_s)
+        params["client_id"] ||= client_id
+        params["post_logout_redirect_uri"] ||= post_logout_redirect_uri
+        params["id_token_hint"] ||= id_token_hint if id_token_hint.present?
+        uri.query = params.to_query
+        uri.to_s
+      rescue URI::InvalidURIError => e
+        Rails.logger.warn("Invalid OIDC end-session endpoint #{end_session_endpoint.inspect}: #{e.message}")
+        nil
+      end
+  end
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,4 +1,6 @@
 class Room < ApplicationRecord
+  SSO_INVITE_PURPOSE = :sso_room_invite
+
   has_many :memberships, dependent: :delete_all do
     def grant_to(users)
       room = proxy_association.owner
@@ -62,6 +64,16 @@ class Room < ApplicationRecord
 
   def default_involvement
     "mentions"
+  end
+
+  def sso_invite_token
+    signed_id(purpose: SSO_INVITE_PURPOSE)
+  end
+
+  def self.find_by_sso_invite_token(token)
+    find_signed(token, purpose: SSO_INVITE_PURPOSE)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -7,8 +7,13 @@ class Session < ApplicationRecord
 
   before_create { self.last_active_at ||= Time.now }
 
-  def self.start!(user_agent:, ip_address:)
-    create! user_agent: user_agent, ip_address: ip_address
+  def self.start!(user_agent:, ip_address:, sso_provider: nil, oidc_id_token: nil)
+    create!(
+      user_agent: user_agent,
+      ip_address: ip_address,
+      sso_provider: sso_provider,
+      oidc_id_token: oidc_id_token
+    )
   end
 
   def resume(user_agent:, ip_address:)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -2,6 +2,7 @@ class Session < ApplicationRecord
   ACTIVITY_REFRESH_RATE = 1.hour
 
   has_secure_token
+  encrypts :oidc_id_token
 
   belongs_to :user
 

--- a/app/models/sso_authentication.rb
+++ b/app/models/sso_authentication.rb
@@ -1,0 +1,87 @@
+class SsoAuthentication
+  class Error < StandardError; end
+
+  EMAIL_ATTRIBUTE_KEYS = [
+    "email",
+    "mail",
+    "emailAddress",
+    "email_address",
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+    "urn:oid:0.9.2342.19200300.100.1.3",
+    "urn:oid:1.2.840.113549.1.9.1"
+  ].freeze
+
+  def self.find_or_create_user_from(auth)
+    provider = auth.provider.to_s
+    uid      = auth.uid.to_s
+    info     = auth.info || OmniAuth::AuthHash::InfoHash.new
+    email    = extract_email(auth:, info:, uid:)
+
+    raise Error, "No email provided by identity provider" if email.blank?
+    raise Error, "No UID provided by identity provider" if uid.blank?
+
+    # Find by SSO identity (returning user)
+    user = User.find_by(sso_provider: provider, sso_uid: uid)
+    return user if user
+
+    # Find by email (link existing user to SSO on first SSO login)
+    user = User.find_by(email_address: email)
+    if user
+      user.update!(sso_provider: provider, sso_uid: uid)
+      return user
+    end
+
+    # Auto-create new user (SSO users bypass join code)
+    User.create!(
+      name: info[:name].presence || email.split("@").first,
+      email_address: email,
+      sso_provider: provider,
+      sso_uid: uid,
+      role: :member
+    )
+  end
+
+  class << self
+    private
+      def extract_email(auth:, info:, uid:)
+        candidate = normalize_email(info.email || info[:email] || info[:mail] || info[:email_address])
+        return candidate if candidate.present?
+
+        raw_info = auth.dig(:extra, :raw_info)
+        candidate = normalize_email(fetch_first(raw_info, EMAIL_ATTRIBUTE_KEYS))
+        return candidate if candidate.present?
+
+        normalize_email(uid) if uid.to_s.include?("@")
+      end
+
+      def fetch_first(container, keys)
+        return if container.nil?
+
+        keys.each do |key|
+          value = fetch_value(container, key)
+          return value if value.present?
+        end
+
+        nil
+      end
+
+      def fetch_value(container, key)
+        return container[key] if container.respond_to?(:[])
+
+        nil
+      rescue StandardError
+        nil
+      end
+
+      def normalize_email(value)
+        email = case value
+        when Array
+          value.find { _1.to_s.include?("@") }
+        else
+          value
+        end
+
+        email.to_s.downcase.strip.presence
+      end
+  end
+end

--- a/app/models/sso_authentication.rb
+++ b/app/models/sso_authentication.rb
@@ -1,6 +1,7 @@
 class SsoAuthentication
   class Error < StandardError; end
 
+  VERIFIED_EMAIL_ATTRIBUTE_KEYS = [ "email_verified", "verified_email" ].freeze
   EMAIL_ATTRIBUTE_KEYS = [
     "email",
     "mail",
@@ -14,19 +15,24 @@ class SsoAuthentication
   def self.find_or_create_user_from(auth)
     provider = auth.provider.to_s
     uid      = auth.uid.to_s
-    info     = auth.info || OmniAuth::AuthHash::InfoHash.new
-    email    = extract_email(auth:, info:, uid:)
 
-    raise Error, "No email provided by identity provider" if email.blank?
     raise Error, "No UID provided by identity provider" if uid.blank?
 
     # Find by SSO identity (returning user)
     user = User.find_by(sso_provider: provider, sso_uid: uid)
     return user if user
 
+    info     = auth.info || OmniAuth::AuthHash::InfoHash.new
+    email    = extract_email(auth:, info:, uid:)
+
+    raise Error, "No email provided by identity provider" if email.blank?
+    raise Error, "Identity provider did not verify the email address" unless email_verified?(auth:, info:)
+
     # Find by email (link existing user to SSO on first SSO login)
-    user = User.find_by(email_address: email)
+    user = User.where("LOWER(email_address) = ?", email).first
     if user
+      raise Error, "Email is already linked to another SSO account" if user.sso?
+
       user.update!(sso_provider: provider, sso_uid: uid)
       return user
     end
@@ -54,12 +60,30 @@ class SsoAuthentication
         normalize_email(uid) if uid.to_s.include?("@")
       end
 
+      def email_verified?(auth:, info:)
+        claim = fetch_first_claim(info, VERIFIED_EMAIL_ATTRIBUTE_KEYS)
+        claim = fetch_first_claim(auth.dig(:extra, :raw_info), VERIFIED_EMAIL_ATTRIBUTE_KEYS) if claim.nil?
+
+        normalize_boolean(claim).in?([ nil, true ])
+      end
+
       def fetch_first(container, keys)
         return if container.nil?
 
         keys.each do |key|
           value = fetch_value(container, key)
           return value if value.present?
+        end
+
+        nil
+      end
+
+      def fetch_first_claim(container, keys)
+        return if container.nil?
+
+        keys.each do |key|
+          value, found = fetch_claim_value(container, key)
+          return value if found
         end
 
         nil
@@ -73,6 +97,15 @@ class SsoAuthentication
         nil
       end
 
+      def fetch_claim_value(container, key)
+        return [ container[key], true ] if container.respond_to?(:key?) && container.key?(key)
+        return [ container[key], true ] if container.respond_to?(:[]) && !container[key].nil?
+
+        [ nil, false ]
+      rescue StandardError
+        [ nil, false ]
+      end
+
       def normalize_email(value)
         email = case value
         when Array
@@ -82,6 +115,19 @@ class SsoAuthentication
         end
 
         email.to_s.downcase.strip.presence
+      end
+
+      def normalize_boolean(value)
+        case value
+        when true, 1
+          true
+        when false, 0
+          false
+        when String
+          value.to_s.strip.downcase.in?(%w[ true 1 yes ])
+        else
+          nil
+        end
       end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,10 @@ class User < ApplicationRecord
   scope :ordered, -> { order("LOWER(name)") }
   scope :filtered_by, ->(query) { where("name like ?", "%#{query}%") }
 
+  def sso?
+    sso_provider.present?
+  end
+
   def initials
     name.scan(/\b\w/).join
   end

--- a/app/views/accounts/_help_contact.html.erb
+++ b/app/views/accounts/_help_contact.html.erb
@@ -1,5 +1,5 @@
 <% if owner = User.administrator.first %>
-  <div class="txt-align-center margin-block-double full-width">
+  <div class="txt-small txt-align-center margin-block-double full-width">
     <%= link_to "mailto:\"#{owner.name}\" <#{owner.email_address}>", class: "btn center", title: "Email #{owner.name}" do %>
       <%= image_tag "lifebuoy.svg", aria: { hidden: "true" } %>
       <span><%= owner.email_address %></span>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -94,9 +94,13 @@
   <% end %>
 
   <div class="margin-block pad-inline pad-block-start fill-shade border-radius">
-    <%= render "accounts/invite" %>
-
-    <hr class="margin-block separator full-width" style="--border-style: solid">
+    <% if password_registration_enabled? %>
+      <%= render "accounts/invite" %>
+      <hr class="margin-block separator full-width" style="--border-style: solid">
+    <% elsif sso_enabled? %>
+      <%= render "rooms/show/sso_invite" %>
+      <hr class="margin-block separator full-width" style="--border-style: solid">
+    <% end %>
 
     <menu class="flex flex-column gap margin-none pad">
       <turbo-frame id="account_users">

--- a/app/views/rooms/layouts/_edit.html.erb
+++ b/app/views/rooms/layouts/_edit.html.erb
@@ -10,6 +10,15 @@
   <%= yield %>
 </section>
 
+<% if Current.user.can_administer?(@room) && !password_registration_enabled? && sso_enabled? %>
+  <section class="panel txt-align-center">
+    <div class="flex flex-column gap center-block upad">
+      <p class="txt-small txt-subtle">People who aren't on Campfire yet can sign in with SSO using this link and will be added to this room on first sign in.</p>
+      <%= render "rooms/show/sso_invite", room: @room %>
+    </div>
+  </section>
+<% end %>
+
 <% if Current.user.can_administer?(@room) %>
   <section class="panel txt-align-center">
     <%= button_to_delete_room room %>

--- a/app/views/rooms/show/_invitation.html.erb
+++ b/app/views/rooms/show/_invitation.html.erb
@@ -9,10 +9,18 @@
           </div>
           <p>
             <strong>Welcome to Campfire</strong><br>
-            To invite people to chat, share the join link below.
+            <% if password_registration_enabled? %>
+              To invite people to chat, share the join link below.
+            <% else %>
+              To invite people to chat, share the link below. They can sign in with SSO.
+            <% end %>
           </p>
         </div>
-        <%= render "accounts/invite" %>
+        <% if password_registration_enabled? %>
+          <%= render "accounts/invite" %>
+        <% else %>
+          <%= render "rooms/show/sso_invite", room: @room %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/rooms/show/_sso_invite.html.erb
+++ b/app/views/rooms/show/_sso_invite.html.erb
@@ -1,0 +1,23 @@
+<% url = local_assigns[:room].present? ? room_url(local_assigns[:room], invite: local_assigns[:room].sso_invite_token) : root_url %>
+
+<div class="flex flex-column align-center gap">
+  <label class="flex flex-column gap full-width" style="--row-gap: 0.5em">
+    <strong id="invite_label" class="invite-label">Share to invite people</strong>
+    <span class="flex align-center gap input input--actor fill-white">
+      <%= image_tag "person-add.svg", aria: { hidden: "true" }, size: 20, class: "colorize--black" %>
+      <input type="text" class="input" id="invite_url" value="<%= url %>" aria-labelledby="invite_label" readonly>
+    </span>
+  </label>
+
+  <div class="flex align-center gap">
+    <%= button_to_copy_to_clipboard(url) do %>
+      <span class="for-screen-reader">Copy link</span>
+      <%= image_tag "copy-paste.svg", aria: { hidden: "true" }, size: 20, class: "colorize--black" %>
+    <% end %>
+
+    <%= web_share_session_button(url, "Join us on Campfire", "Sign in to join us on Campfire.") do %>
+      <span class="for-screen-reader">Share link</span>
+      <%= image_tag "share.svg", aria: { hidden: "true" }, size: 20, class: "colorize--black" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,33 +5,96 @@
   <div class="panel <%= "shake" if flash[:alert] %>">
     <%= account_logo_tag style: "center margin-block-end txt-xx-large" %>
 
-    <%= form_with url: session_url, class: "flex flex-column gap" do |form| %>
-      <fieldset class="flex flex-column gap center-block upad">
-        <legend class="txt-large txt-align-center"><strong><%= Current.account.name %></strong></legend>
+    <% if flash[:alert] %>
+      <p class="txt-small txt-negative pad-inline" role="alert"><%= flash[:alert] %></p>
+    <% end %>
 
-        <div class="flex align-center gap">
-          <%= translation_button(:email_address) %>
-          <label class="flex align-center gap input input--actor txt-large">
-            <%= form.email_field :email_address, required: true, class: "input", autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %>
-            <%= image_tag "email.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
-          </label>
-        </div>
+    <% if sso_enabled? && !password_registration_enabled? %>
+      <%# SSO-first layout: SSO buttons prominent, password form collapsed %>
+      <div class="flex flex-column gap center-block upad">
+        <strong class="txt-large txt-align-center"><%= Current.account.name %></strong>
 
-        <div class="flex align-center gap">
-          <%= translation_button(:password) %>
-          <label class="flex align-center gap input input--actor txt-large">
-            <%= form.password_field :password, required: true, class: "input", autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %>
-            <%= image_tag "password.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
-          </label>
-        </div>
-
-        <%= form.button class: "btn btn--reversed center txt-large", type: "submit", name: "log_in" do %>
-          <%= image_tag "arrow-right.svg", aria: { hidden: "true" } %>
-          <span class="for-screen-reader">Go</span>
+        <% oidc_providers.each do |provider| %>
+          <%= form_with url: "/auth/#{provider.fetch(:strategy)}", data: { turbo: false } do %>
+            <button type="submit" class="btn btn--reversed center txt-large">Sign in with <%= provider.fetch(:display_name) %></button>
+          <% end %>
         <% end %>
-      </fieldset>
+      </div>
+
+      <details class="margin-block-start">
+        <summary class="btn txt-small txt-subtle center">Sign in with email and password</summary>
+        <div class="margin-block-start">
+          <%= form_with url: session_url, class: "flex flex-column gap" do |form| %>
+            <fieldset class="flex flex-column gap center-block upad">
+              <div class="flex align-center gap">
+                <%= translation_button(:email_address) %>
+                <label class="flex align-center gap input input--actor txt-large">
+                  <%= form.email_field :email_address, required: true, class: "input", autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %>
+                  <%= image_tag "email.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
+                </label>
+              </div>
+
+              <div class="flex align-center gap">
+                <%= translation_button(:password) %>
+                <label class="flex align-center gap input input--actor txt-large">
+                  <%= form.password_field :password, required: true, class: "input", autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %>
+                  <%= image_tag "password.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
+                </label>
+              </div>
+
+              <%= form.button class: "btn btn--reversed center txt-large", type: "submit", name: "log_in" do %>
+                <%= image_tag "arrow-right.svg", aria: { hidden: "true" } %>
+                <span class="for-screen-reader">Go</span>
+              <% end %>
+            </fieldset>
+          <% end %>
+        </div>
+      </details>
+
+    <% else %>
+      <%# Default layout: password form first, SSO below %>
+      <%= form_with url: session_url, class: "flex flex-column gap" do |form| %>
+        <fieldset class="flex flex-column gap center-block upad">
+          <legend class="txt-large txt-align-center"><strong><%= Current.account.name %></strong></legend>
+
+          <div class="flex align-center gap">
+            <%= translation_button(:email_address) %>
+            <label class="flex align-center gap input input--actor txt-large">
+              <%= form.email_field :email_address, required: true, class: "input", autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %>
+              <%= image_tag "email.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
+            </label>
+          </div>
+
+          <div class="flex align-center gap">
+            <%= translation_button(:password) %>
+            <label class="flex align-center gap input input--actor txt-large">
+              <%= form.password_field :password, required: true, class: "input", autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %>
+              <%= image_tag "password.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
+            </label>
+          </div>
+
+          <%= form.button class: "btn btn--reversed center txt-large", type: "submit", name: "log_in" do %>
+            <%= image_tag "arrow-right.svg", aria: { hidden: "true" } %>
+            <span class="for-screen-reader">Go</span>
+          <% end %>
+        </fieldset>
+      <% end %>
     <% end %>
   </div>
+
+  <% if sso_enabled? && password_registration_enabled? %>
+    <div class="panel margin-block">
+      <div class="flex flex-column gap center-block upad">
+        <strong class="txt-large txt-align-center">Or sign in with</strong>
+
+        <% oidc_providers.each do |provider| %>
+          <%= form_with url: "/auth/#{provider.fetch(:strategy)}", data: { turbo: false } do %>
+            <button type="submit" class="btn btn--reversed center txt-large"><%= provider.fetch(:display_name) %></button>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 
   <%= render "accounts/help_contact" %>
 </section>

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="flex-item-justify-end">
-    <%= form_with url: session_path, method: :delete, data: { controller: "sessions" } do %>
+    <%= form_with url: session_path, method: :delete, data: { controller: "sessions", turbo: false } do %>
       <%= hidden_field_tag :push_subscription_endpoint, nil, data: { sessions_target: "pushSubscriptionEndpoint" } %>
 
       <button class="btn" data-action="sessions#logout:prevent">
@@ -54,7 +54,7 @@
 
         <label class="flex align-center gap flex-item-grow input input--actor">
           <%= form.text_field :name, class: "input txt-large ", autocomplete: "name", placeholder: "Enter your name",
-                autofocus: true, required: true,  data: { "1p-ignore": true } %>
+                autofocus: true, required: true, disabled: @user.sso?, data: { "1p-ignore": true } %>
           <%= image_tag "person.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
         </label>
       </div>
@@ -64,20 +64,22 @@
 
         <label class="flex align-center gap flex-item-grow input input--actor">
           <%= form.email_field :email_address, class: "input txt-large", value: @user.email_address, autocomplete: "username",
-                placeholder: "Enter your email address", required: false %>
+                placeholder: "Enter your email address", required: false, disabled: @user.sso? %>
           <%= image_tag "email.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
         </label>
       </div>
 
-      <div class="flex align-center gap">
-        <%= translation_button(:update_password) %>
+      <% if password_registration_enabled? %>
+        <div class="flex align-center gap">
+          <%= translation_button(:update_password) %>
 
-        <label class="flex align-center gap flex-item-grow input input--actor">
-          <%= form.password_field :password, class: "input txt-large", autocomplete: "new-password", placeholder: "Change password",
-                required: false, maxlength: 72 %>
-          <%= image_tag "password.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
-        </label>
-      </div>
+          <label class="flex align-center gap flex-item-grow input input--actor">
+            <%= form.password_field :password, class: "input txt-large", autocomplete: "new-password", placeholder: "Change password",
+                  required: false, maxlength: 72 %>
+            <%= image_tag "password.svg", aria: { hidden: "true" }, size: 24, class: "colorize--black" %>
+          </label>
+        </div>
+      <% end %>
 
       <div class="flex align-start gap">
         <%= translation_button(:bio) %>

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -69,7 +69,7 @@
         </label>
       </div>
 
-      <% if password_registration_enabled? %>
+      <% if !@user.sso? || password_registration_enabled? %>
         <div class="flex align-center gap">
           <%= translation_button(:update_password) %>
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,31 @@
+services:
+  campfire:
+    image: ghcr.io/basecamp/once-campfire:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: campfire
+    restart: unless-stopped
+    ports:
+      - "4267:80"
+      - "3473:443"
+    env_file:
+      - .env
+    volumes:
+      - campfire_storage:/rails/storage
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost/up || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    security_opt:
+      - no-new-privileges:true
+    develop:
+      watch:
+        - action: rebuild
+          path: .
+
+volumes:
+  campfire_storage:
+    driver: local

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,0 +1,15 @@
+key_generator = Rails.application.key_generator
+credentials = Rails.application.credentials
+configured_keys = credentials.respond_to?(:dig) ? credentials.dig(:active_record_encryption) : nil
+
+ActiveRecord::Encryption.configure(
+  primary_key: ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"] ||
+    configured_keys&.dig(:primary_key) ||
+    key_generator.generate_key("active_record_encryption.primary_key", 32),
+  deterministic_key: ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"] ||
+    configured_keys&.dig(:deterministic_key) ||
+    key_generator.generate_key("active_record_encryption.deterministic_key", 32),
+  key_derivation_salt: ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"] ||
+    configured_keys&.dig(:key_derivation_salt) ||
+    key_generator.generate_key("active_record_encryption.key_derivation_salt", 32)
+)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,23 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  # OIDC Providers (Keycloak, Okta, Azure AD, Google Workspace)
+  OidcConfiguration.providers.each do |provider_config|
+    provider :openid_connect,
+      name: provider_config.fetch(:strategy),
+      scope: provider_config.fetch(:scope),
+      response_type: :code,
+      issuer: provider_config.fetch(:issuer),
+      discovery: true,
+      client_auth_method: provider_config.fetch(:client_auth_method),
+      client_options: {
+        identifier: provider_config.fetch(:client_id),
+        secret: provider_config.fetch(:client_secret),
+        redirect_uri: provider_config.fetch(:redirect_uri)
+      }
+  end
+end
+
+OmniAuth.config.logger = Rails.logger
+
+OmniAuth.config.on_failure = Proc.new do |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # OIDC callbacks (OmniAuth handles /auth/:provider request phase via middleware)
+  get  "auth/:provider/callback", to: "sso_sessions#create", as: :sso_callback
+  get  "auth/failure",            to: "sso_sessions#failure", as: :sso_failure
+
   resource :account do
     scope module: "accounts" do
       resources :users

--- a/db/migrate/20260424120000_add_sso_fields_to_users.rb
+++ b/db/migrate/20260424120000_add_sso_fields_to_users.rb
@@ -2,6 +2,9 @@ class AddSsoFieldsToUsers < ActiveRecord::Migration[8.2]
   def change
     add_column :users, :sso_provider, :string
     add_column :users, :sso_uid, :string
-    add_index :users, [ :sso_provider, :sso_uid ], unique: true, where: "sso_provider IS NOT NULL"
+    add_check_constraint :users,
+      "(sso_provider IS NULL) = (sso_uid IS NULL)",
+      name: "users_sso_provider_uid_presence_match"
+    add_index :users, [ :sso_provider, :sso_uid ], unique: true, where: "sso_provider IS NOT NULL AND sso_uid IS NOT NULL"
   end
 end

--- a/db/migrate/20260424120000_add_sso_fields_to_users.rb
+++ b/db/migrate/20260424120000_add_sso_fields_to_users.rb
@@ -1,0 +1,7 @@
+class AddSsoFieldsToUsers < ActiveRecord::Migration[8.2]
+  def change
+    add_column :users, :sso_provider, :string
+    add_column :users, :sso_uid, :string
+    add_index :users, [ :sso_provider, :sso_uid ], unique: true, where: "sso_provider IS NOT NULL"
+  end
+end

--- a/db/migrate/20260426163000_add_sso_provider_to_sessions.rb
+++ b/db/migrate/20260426163000_add_sso_provider_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddSsoProviderToSessions < ActiveRecord::Migration[8.2]
+  def change
+    add_column :sessions, :sso_provider, :string
+  end
+end

--- a/db/migrate/20260426170000_add_oidc_id_token_to_sessions.rb
+++ b/db/migrate/20260426170000_add_oidc_id_token_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddOidcIdTokenToSessions < ActiveRecord::Migration[8.2]
+  def change
+    add_column :sessions, :oidc_id_token, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -160,7 +160,8 @@ ActiveRecord::Schema[8.2].define(version: 2026_04_26_170000) do
     t.datetime "updated_at", null: false
     t.index ["bot_token"], name: "index_users_on_bot_token", unique: true
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
-    t.index ["sso_provider", "sso_uid"], name: "index_users_on_sso_provider_and_sso_uid", unique: true, where: "sso_provider IS NOT NULL"
+    t.index ["sso_provider", "sso_uid"], name: "index_users_on_sso_provider_and_sso_uid", unique: true, where: "sso_provider IS NOT NULL AND sso_uid IS NOT NULL"
+    t.check_constraint "(sso_provider IS NULL) = (sso_uid IS NULL)", name: "users_sso_provider_uid_presence_match"
   end
 
   create_table "webhooks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
+ActiveRecord::Schema[8.2].define(version: 2026_04_26_170000) do
   create_table "accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "custom_styles"
@@ -136,6 +136,8 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
     t.datetime "created_at", null: false
     t.string "ip_address"
     t.datetime "last_active_at", null: false
+    t.text "oidc_id_token"
+    t.string "sso_provider"
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.string "user_agent"
@@ -152,10 +154,13 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
     t.string "name", null: false
     t.string "password_digest"
     t.integer "role", default: 0, null: false
+    t.string "sso_provider"
+    t.string "sso_uid"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["bot_token"], name: "index_users_on_bot_token", unique: true
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["sso_provider", "sso_uid"], name: "index_users_on_sso_provider_and_sso_uid", unique: true, where: "sso_provider IS NOT NULL"
   end
 
   create_table "webhooks", force: :cascade do |t|

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -15,6 +15,32 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show grants membership with a valid invite token for signed-in users" do
+    sign_in :jz
+    room = rooms(:watercooler)
+
+    assert_no_difference -> { Session.count } do
+      assert_difference -> { room.memberships.count }, +1 do
+        get room_url(room, invite: room.sso_invite_token)
+      end
+    end
+
+    assert_response :success
+    assert room.users.exists?(id: users(:jz).id)
+  end
+
+  test "show does not grant membership with an invalid invite token for signed-in users" do
+    sign_in :jz
+    room = rooms(:watercooler)
+
+    assert_no_difference -> { room.memberships.count } do
+      get room_url(room, invite: "invalid-token")
+    end
+
+    assert_redirected_to root_url
+    assert_not room.users.exists?(id: users(:jz).id)
+  end
+
   test "shows records the last room visited in a cookie" do
     get room_url(users(:david).rooms.last)
     assert response.cookies[:last_room] = users(:david).rooms.last.id

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -27,6 +27,70 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", text: /Upgrade to a supported web browser/, count: 0
   end
 
+  test "new in SSO-first mode does not render the secondary SSO panel" do
+    original_oidc_providers = ENV["OIDC_PROVIDERS"]
+    original_oidc_test_issuer = ENV["OIDC_TEST_ISSUER"]
+    original_oidc_test_client_id = ENV["OIDC_TEST_CLIENT_ID"]
+    original_oidc_test_client_secret = ENV["OIDC_TEST_CLIENT_SECRET"]
+    original_oidc_test_redirect_uri = ENV["OIDC_TEST_REDIRECT_URI"]
+    original_oidc_test_provider_name = ENV["OIDC_TEST_PROVIDER_NAME"]
+    original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
+
+    ENV["OIDC_PROVIDERS"] = "test"
+    ENV["OIDC_TEST_ISSUER"] = "https://idp.example.test/realms/campfire"
+    ENV["OIDC_TEST_CLIENT_ID"] = "test-client-id"
+    ENV["OIDC_TEST_CLIENT_SECRET"] = "test-client-secret"
+    ENV["OIDC_TEST_REDIRECT_URI"] = "https://campfire.example.test/auth/oidc_test/callback"
+    ENV["OIDC_TEST_PROVIDER_NAME"] = "Test OIDC"
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
+
+    get new_session_url
+
+    assert_response :success
+    assert_select "summary", text: "Sign in with email and password"
+    assert_select "strong", text: "Or sign in with", count: 0
+  ensure
+    ENV["OIDC_PROVIDERS"] = original_oidc_providers
+    ENV["OIDC_TEST_ISSUER"] = original_oidc_test_issuer
+    ENV["OIDC_TEST_CLIENT_ID"] = original_oidc_test_client_id
+    ENV["OIDC_TEST_CLIENT_SECRET"] = original_oidc_test_client_secret
+    ENV["OIDC_TEST_REDIRECT_URI"] = original_oidc_test_redirect_uri
+    ENV["OIDC_TEST_PROVIDER_NAME"] = original_oidc_test_provider_name
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = original_disable_password_registration
+  end
+
+  test "new uses configured OIDC provider label and callback-derived strategy" do
+    original_oidc_providers = ENV["OIDC_PROVIDERS"]
+    original_oidc_keycloak_issuer = ENV["OIDC_KEYCLOAK_ISSUER"]
+    original_oidc_keycloak_client_id = ENV["OIDC_KEYCLOAK_CLIENT_ID"]
+    original_oidc_keycloak_client_secret = ENV["OIDC_KEYCLOAK_CLIENT_SECRET"]
+    original_oidc_keycloak_redirect_uri = ENV["OIDC_KEYCLOAK_REDIRECT_URI"]
+    original_oidc_keycloak_provider_name = ENV["OIDC_KEYCLOAK_PROVIDER_NAME"]
+    original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
+
+    ENV["OIDC_PROVIDERS"] = "keycloak"
+    ENV["OIDC_KEYCLOAK_ISSUER"] = "https://idp.example.test/realms/campfire"
+    ENV["OIDC_KEYCLOAK_CLIENT_ID"] = "campfire"
+    ENV["OIDC_KEYCLOAK_CLIENT_SECRET"] = "secret"
+    ENV["OIDC_KEYCLOAK_REDIRECT_URI"] = "https://campfire.example.test/auth/oidc/callback"
+    ENV["OIDC_KEYCLOAK_PROVIDER_NAME"] = "BloxWeaver OIDC"
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
+
+    get new_session_url
+
+    assert_response :success
+    assert_select "button", text: "Sign in with BloxWeaver OIDC"
+    assert_select "form[action='/auth/oidc']"
+  ensure
+    ENV["OIDC_PROVIDERS"] = original_oidc_providers
+    ENV["OIDC_KEYCLOAK_ISSUER"] = original_oidc_keycloak_issuer
+    ENV["OIDC_KEYCLOAK_CLIENT_ID"] = original_oidc_keycloak_client_id
+    ENV["OIDC_KEYCLOAK_CLIENT_SECRET"] = original_oidc_keycloak_client_secret
+    ENV["OIDC_KEYCLOAK_REDIRECT_URI"] = original_oidc_keycloak_redirect_uri
+    ENV["OIDC_KEYCLOAK_PROVIDER_NAME"] = original_oidc_keycloak_provider_name
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = original_disable_password_registration
+  end
+
   test "create with valid credentials" do
     assert_difference -> { Session.count }, +1 do
       post session_url, params: { email_address: "david@37signals.com", password: "secret123456" }
@@ -52,6 +116,25 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to root_url
+    assert_not cookies[:session_token].present?
+    assert_nil Session.find_by(id: session.id)
+  end
+
+  test "destroy redirects through OIDC provider logout for OIDC-backed sessions" do
+    sign_in :david
+    session = Session.find_by(token: parsed_cookies.signed[:session_token])
+    session.update!(sso_provider: "oidc", oidc_id_token: "jwt-id-token")
+
+    logout_url = "https://idp.example.test/logout?client_id=campfire"
+
+    OidcLogout.expects(:logout_url_for).with(
+      strategy: "oidc",
+      id_token_hint: "jwt-id-token",
+      post_logout_redirect_uri: root_url
+    ).returns(logout_url)
+    delete session_url
+
+    assert_redirected_to logout_url
     assert_not cookies[:session_token].present?
     assert_nil Session.find_by(id: session.id)
   end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -28,67 +28,39 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "new in SSO-first mode does not render the secondary SSO panel" do
-    original_oidc_providers = ENV["OIDC_PROVIDERS"]
-    original_oidc_test_issuer = ENV["OIDC_TEST_ISSUER"]
-    original_oidc_test_client_id = ENV["OIDC_TEST_CLIENT_ID"]
-    original_oidc_test_client_secret = ENV["OIDC_TEST_CLIENT_SECRET"]
-    original_oidc_test_redirect_uri = ENV["OIDC_TEST_REDIRECT_URI"]
-    original_oidc_test_provider_name = ENV["OIDC_TEST_PROVIDER_NAME"]
-    original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
+    with_env(
+      "OIDC_PROVIDERS" => "test",
+      "OIDC_TEST_ISSUER" => "https://idp.example.test/realms/campfire",
+      "OIDC_TEST_CLIENT_ID" => "test-client-id",
+      "OIDC_TEST_CLIENT_SECRET" => "test-client-secret",
+      "OIDC_TEST_REDIRECT_URI" => "https://campfire.example.test/auth/oidc_test/callback",
+      "OIDC_TEST_PROVIDER_NAME" => "Test OIDC",
+      "DISABLE_PASSWORD_REGISTRATION" => "true"
+    ) do
+      get new_session_url
 
-    ENV["OIDC_PROVIDERS"] = "test"
-    ENV["OIDC_TEST_ISSUER"] = "https://idp.example.test/realms/campfire"
-    ENV["OIDC_TEST_CLIENT_ID"] = "test-client-id"
-    ENV["OIDC_TEST_CLIENT_SECRET"] = "test-client-secret"
-    ENV["OIDC_TEST_REDIRECT_URI"] = "https://campfire.example.test/auth/oidc_test/callback"
-    ENV["OIDC_TEST_PROVIDER_NAME"] = "Test OIDC"
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
-
-    get new_session_url
-
-    assert_response :success
-    assert_select "summary", text: "Sign in with email and password"
-    assert_select "strong", text: "Or sign in with", count: 0
-  ensure
-    ENV["OIDC_PROVIDERS"] = original_oidc_providers
-    ENV["OIDC_TEST_ISSUER"] = original_oidc_test_issuer
-    ENV["OIDC_TEST_CLIENT_ID"] = original_oidc_test_client_id
-    ENV["OIDC_TEST_CLIENT_SECRET"] = original_oidc_test_client_secret
-    ENV["OIDC_TEST_REDIRECT_URI"] = original_oidc_test_redirect_uri
-    ENV["OIDC_TEST_PROVIDER_NAME"] = original_oidc_test_provider_name
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = original_disable_password_registration
+      assert_response :success
+      assert_select "summary", text: "Sign in with email and password"
+      assert_select "strong", text: "Or sign in with", count: 0
+    end
   end
 
   test "new uses configured OIDC provider label and callback-derived strategy" do
-    original_oidc_providers = ENV["OIDC_PROVIDERS"]
-    original_oidc_keycloak_issuer = ENV["OIDC_KEYCLOAK_ISSUER"]
-    original_oidc_keycloak_client_id = ENV["OIDC_KEYCLOAK_CLIENT_ID"]
-    original_oidc_keycloak_client_secret = ENV["OIDC_KEYCLOAK_CLIENT_SECRET"]
-    original_oidc_keycloak_redirect_uri = ENV["OIDC_KEYCLOAK_REDIRECT_URI"]
-    original_oidc_keycloak_provider_name = ENV["OIDC_KEYCLOAK_PROVIDER_NAME"]
-    original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
+    with_env(
+      "OIDC_PROVIDERS" => "keycloak",
+      "OIDC_KEYCLOAK_ISSUER" => "https://idp.example.test/realms/campfire",
+      "OIDC_KEYCLOAK_CLIENT_ID" => "campfire",
+      "OIDC_KEYCLOAK_CLIENT_SECRET" => "secret",
+      "OIDC_KEYCLOAK_REDIRECT_URI" => "https://campfire.example.test/auth/oidc/callback",
+      "OIDC_KEYCLOAK_PROVIDER_NAME" => "BloxWeaver OIDC",
+      "DISABLE_PASSWORD_REGISTRATION" => "true"
+    ) do
+      get new_session_url
 
-    ENV["OIDC_PROVIDERS"] = "keycloak"
-    ENV["OIDC_KEYCLOAK_ISSUER"] = "https://idp.example.test/realms/campfire"
-    ENV["OIDC_KEYCLOAK_CLIENT_ID"] = "campfire"
-    ENV["OIDC_KEYCLOAK_CLIENT_SECRET"] = "secret"
-    ENV["OIDC_KEYCLOAK_REDIRECT_URI"] = "https://campfire.example.test/auth/oidc/callback"
-    ENV["OIDC_KEYCLOAK_PROVIDER_NAME"] = "BloxWeaver OIDC"
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
-
-    get new_session_url
-
-    assert_response :success
-    assert_select "button", text: "Sign in with BloxWeaver OIDC"
-    assert_select "form[action='/auth/oidc']"
-  ensure
-    ENV["OIDC_PROVIDERS"] = original_oidc_providers
-    ENV["OIDC_KEYCLOAK_ISSUER"] = original_oidc_keycloak_issuer
-    ENV["OIDC_KEYCLOAK_CLIENT_ID"] = original_oidc_keycloak_client_id
-    ENV["OIDC_KEYCLOAK_CLIENT_SECRET"] = original_oidc_keycloak_client_secret
-    ENV["OIDC_KEYCLOAK_REDIRECT_URI"] = original_oidc_keycloak_redirect_uri
-    ENV["OIDC_KEYCLOAK_PROVIDER_NAME"] = original_oidc_keycloak_provider_name
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = original_disable_password_registration
+      assert_response :success
+      assert_select "button", text: "Sign in with BloxWeaver OIDC"
+      assert_select "form[action='/auth/oidc']"
+    end
   end
 
   test "create with valid credentials" do

--- a/test/controllers/sso_sessions_controller_test.rb
+++ b/test/controllers/sso_sessions_controller_test.rb
@@ -1,0 +1,135 @@
+require "test_helper"
+
+class SsoSessionsControllerTest < ActionDispatch::IntegrationTest
+  OIDC_PROVIDER = :oidc_test
+
+  setup do
+    set_omniauth_auth(provider: OIDC_PROVIDER, uid: "idp-uid-123", email: "newuser@example.com", name: "New User")
+  end
+
+  teardown do
+    clear_omniauth_auth
+  end
+
+  test "OIDC callback creates session for new user" do
+    assert_difference [ -> { User.count }, -> { Session.count } ], +1 do
+      get sso_callback_url(provider: OIDC_PROVIDER)
+    end
+
+    assert_redirected_to root_url
+    assert cookies[:session_token].present?
+    assert_equal OIDC_PROVIDER.to_s, Session.find_by(token: parsed_cookies.signed[:session_token]).sso_provider
+  end
+
+  test "OIDC callback stores id token hint on the session" do
+    set_omniauth_auth(
+      provider: OIDC_PROVIDER,
+      uid: "idp-uid-token-1",
+      email: "idtoken@example.com",
+      id_token: "jwt-id-token"
+    )
+
+    get sso_callback_url(provider: OIDC_PROVIDER)
+
+    session = Session.find_by(token: parsed_cookies.signed[:session_token])
+    assert_equal "jwt-id-token", session.oidc_id_token
+  end
+
+  test "OIDC callback creates session for existing user matched by email" do
+    user = users(:jz)
+    set_omniauth_auth(provider: OIDC_PROVIDER, uid: "idp-uid-jz", email: user.email_address, name: user.name)
+
+    assert_no_difference -> { User.count } do
+      get sso_callback_url(provider: OIDC_PROVIDER)
+    end
+
+    assert_redirected_to root_url
+    assert cookies[:session_token].present?
+    assert_equal OIDC_PROVIDER.to_s, user.reload.sso_provider
+    assert_equal "idp-uid-jz", user.sso_uid
+  end
+
+  test "OIDC callback creates session for returning SSO user" do
+    user = users(:jz)
+    user.update!(sso_provider: OIDC_PROVIDER.to_s, sso_uid: "idp-uid-jz")
+    set_omniauth_auth(provider: OIDC_PROVIDER, uid: "idp-uid-jz", email: user.email_address, name: user.name)
+
+    assert_no_difference -> { User.count } do
+      get sso_callback_url(provider: OIDC_PROVIDER)
+    end
+
+    assert_redirected_to root_url
+    assert cookies[:session_token].present?
+  end
+
+  test "first SSO login from a room invite grants membership to that room" do
+    room = rooms(:watercooler)
+    invite_url = room_url(room, invite: room.sso_invite_token)
+
+    get invite_url
+    assert_redirected_to new_session_url
+
+    assert_difference -> { room.memberships.count }, +1 do
+      get sso_callback_url(provider: OIDC_PROVIDER)
+    end
+
+    assert_redirected_to invite_url
+    assert room.users.exists?(email_address: "newuser@example.com")
+  end
+
+  test "first SSO login ignores invalid room invite token" do
+    room = rooms(:watercooler)
+    invite_url = room_url(room, invite: "invalid-token")
+
+    get invite_url
+    assert_redirected_to new_session_url
+
+    assert_no_difference -> { room.memberships.count } do
+      get sso_callback_url(provider: OIDC_PROVIDER)
+    end
+
+    assert_redirected_to invite_url
+    assert_not room.users.exists?(email_address: "newuser@example.com")
+  end
+
+  test "callback blocks deactivated user" do
+    user = users(:jz)
+    user.update!(status: :deactivated, sso_provider: OIDC_PROVIDER.to_s, sso_uid: "idp-uid-jz")
+    set_omniauth_auth(provider: OIDC_PROVIDER, uid: "idp-uid-jz", email: user.email_address)
+
+    get sso_callback_url(provider: OIDC_PROVIDER)
+
+    assert_redirected_to new_session_url
+    assert_equal "Your account has been deactivated.", flash[:alert]
+  end
+
+  test "OIDC callback redirects to login when omniauth.auth is missing" do
+    clear_omniauth_auth
+
+    get sso_callback_url(provider: OIDC_PROVIDER)
+
+    assert_redirected_to new_session_url
+  end
+
+  test "failure redirects to login with error message" do
+    get sso_failure_url(message: "invalid_credentials", strategy: "oidc")
+
+    assert_redirected_to new_session_url
+    assert_match "SSO authentication failed", flash[:alert]
+    assert_match "Invalid credentials", flash[:alert]
+  end
+
+  test "failure shows detailed message when provided" do
+    get sso_failure_url(message: "invalid_credentials", strategy: "oidc", detail: "Issuer mismatch")
+
+    assert_redirected_to new_session_url
+    assert_match "Issuer mismatch", flash[:alert]
+  end
+
+  test "failure truncates large detail message" do
+    get sso_failure_url(message: "invalid_credentials", strategy: "oidc", detail: ("a" * 1000))
+
+    assert_redirected_to new_session_url
+    assert_operator flash[:alert].length, :<=, 400
+  end
+end

--- a/test/controllers/users/profiles_controller_test.rb
+++ b/test/controllers/users/profiles_controller_test.rb
@@ -38,6 +38,13 @@ class Users::ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='user[email_address]'][disabled]"
   end
 
+  test "show keeps password field for non-SSO users when password registration is disabled" do
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "true") do
+      get user_profile_url
+      assert_select "input[name='user[password]']"
+    end
+  end
+
   test "update ignores SSO name and email changes" do
     sso_user = users(:sso_user)
     sso_user.update!(password: "secret123456")

--- a/test/controllers/users/profiles_controller_test.rb
+++ b/test/controllers/users/profiles_controller_test.rb
@@ -9,6 +9,7 @@ class Users::ProfilesControllerTest < ActionDispatch::IntegrationTest
     get user_profile_url
 
     assert_response :success
+    assert_select "form[data-controller='sessions'][data-turbo='false']"
   end
 
   test "update" do
@@ -24,5 +25,29 @@ class Users::ProfilesControllerTest < ActionDispatch::IntegrationTest
     put user_profile_url(users(:jason)), params: { user: { name: "John Doe" } }
 
     assert_equal "Jason", users(:jason).reload.name
+  end
+
+  test "show disables name and email fields for SSO users" do
+    sso_user = users(:sso_user)
+    sso_user.update!(password: "secret123456")
+    sign_in sso_user
+
+    get user_profile_url
+
+    assert_select "input[name='user[name]'][disabled]"
+    assert_select "input[name='user[email_address]'][disabled]"
+  end
+
+  test "update ignores SSO name and email changes" do
+    sso_user = users(:sso_user)
+    sso_user.update!(password: "secret123456")
+    sign_in sso_user
+
+    put user_profile_url, params: { user: { name: "Renamed", email_address: "renamed@example.com", bio: "Updated bio" } }
+
+    assert_redirected_to user_profile_url
+    assert_equal "SSO User", sso_user.reload.name
+    assert_equal "sso@example.com", sso_user.email_address
+    assert_equal "Updated bio", sso_user.bio
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,7 +2,13 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
+    @original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = "false"
     @join_code = accounts(:signal).join_code
+  end
+
+  teardown do
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = @original_disable_password_registration
   end
 
   test "show" do
@@ -38,6 +44,20 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = User.last
     assert_equal user.id, Session.find_by(token: parsed_cookies.signed[:session_token]).user.id
     assert_equal Rooms::Open.all, user.rooms
+  end
+
+  test "new redirects to login when password registration is disabled" do
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
+    get join_url(@join_code)
+    assert_redirected_to new_session_url
+  end
+
+  test "create redirects to login when password registration is disabled" do
+    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
+    assert_no_difference -> { User.count } do
+      post join_url(@join_code), params: { user: { name: "New Person", email_address: "new@37signals.com", password: "secret123456" } }
+    end
+    assert_redirected_to new_session_url
   end
 
   test "creating a new user with an existing email address will redirect to login screen" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,69 +2,84 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @original_disable_password_registration = ENV["DISABLE_PASSWORD_REGISTRATION"]
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = "false"
     @join_code = accounts(:signal).join_code
   end
 
-  teardown do
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = @original_disable_password_registration
-  end
-
   test "show" do
-    sign_in :david
-    get user_url(users(:david))
-    assert_response :ok
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      sign_in :david
+      get user_url(users(:david))
+      assert_response :ok
+    end
   end
 
   test "new" do
-    get join_url(@join_code)
-    assert_response :success
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      get join_url(@join_code)
+      assert_response :success
+    end
   end
 
   test "new does not allow a signed in user" do
-    sign_in :david
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      sign_in :david
 
-    get join_url(@join_code)
-    assert_redirected_to root_url
+      get join_url(@join_code)
+      assert_redirected_to root_url
+    end
   end
 
   test "new requires a join code" do
-    get join_url("not")
-    assert_response :not_found
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      get join_url("not")
+      assert_response :not_found
+    end
   end
 
   test "create" do
-    assert_difference -> { User.count }, 1 do
-      post join_url(@join_code), params: { user: { name: "New Person", email_address: "new@37signals.com", password: "secret123456" } }
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      assert_difference -> { User.count }, 1 do
+        post join_url(@join_code), params: { user: { name: "New Person", email_address: "new@37signals.com", password: "secret123456" } }
+      end
+
+      assert_redirected_to root_url
+
+      user = User.last
+      assert_equal user.id, Session.find_by(token: parsed_cookies.signed[:session_token]).user.id
+      assert_equal Rooms::Open.all, user.rooms
     end
-
-    assert_redirected_to root_url
-
-    user = User.last
-    assert_equal user.id, Session.find_by(token: parsed_cookies.signed[:session_token]).user.id
-    assert_equal Rooms::Open.all, user.rooms
   end
 
   test "new redirects to login when password registration is disabled" do
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
-    get join_url(@join_code)
-    assert_redirected_to new_session_url
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "true") do
+      get join_url(@join_code)
+      assert_redirected_to new_session_url
+    end
   end
 
   test "create redirects to login when password registration is disabled" do
-    ENV["DISABLE_PASSWORD_REGISTRATION"] = "true"
-    assert_no_difference -> { User.count } do
-      post join_url(@join_code), params: { user: { name: "New Person", email_address: "new@37signals.com", password: "secret123456" } }
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "true") do
+      assert_no_difference -> { User.count } do
+        post join_url(@join_code), params: { user: { name: "New Person", email_address: "new@37signals.com", password: "secret123456" } }
+      end
+      assert_redirected_to new_session_url
     end
-    assert_redirected_to new_session_url
   end
 
   test "creating a new user with an existing email address will redirect to login screen" do
-    assert_no_difference -> { User.count } do
-      post join_url(@join_code), params: { user: { name: "Another David", email_address: users(:david).email_address, password: "secret123456" } }
-    end
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "false") do
+      assert_no_difference -> { User.count } do
+        post join_url(@join_code), params: { user: { name: "Another David", email_address: users(:david).email_address, password: "secret123456" } }
+      end
 
-    assert_redirected_to new_session_url(email_address: users(:david).email_address)
+      assert_redirected_to new_session_url(email_address: users(:david).email_address)
+    end
+  end
+
+  test "password registration toggle treats uppercase true as disabled" do
+    with_env("DISABLE_PASSWORD_REGISTRATION" => "TRUE") do
+      get join_url(@join_code)
+      assert_redirected_to new_session_url
+    end
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -28,3 +28,9 @@ bender:
   name: Bender Bot
   bot_token: <%= User.generate_bot_token %>
   role: bot
+
+sso_user:
+  name: SSO User
+  email_address: sso@example.com
+  sso_provider: oidc
+  sso_uid: sso-fixture-uid-001

--- a/test/models/oidc_configuration_test.rb
+++ b/test/models/oidc_configuration_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+
+class OidcConfigurationTest < ActiveSupport::TestCase
+  test "returns no providers when OIDC_PROVIDERS is unset" do
+    assert_equal [], OidcConfiguration.providers(env: {})
+  end
+
+  test "builds multiple providers with expected strategy names" do
+    providers = OidcConfiguration.providers(
+      env: base_env.merge(
+        "OIDC_PROVIDERS" => "google, azure_ad"
+      )
+    )
+
+    assert_equal %w[oidc_google oidc_azure_ad], providers.map { _1.fetch(:strategy) }
+    assert_equal [ "Google", "Azure Ad" ], providers.map { _1.fetch(:display_name) }
+    assert_equal [ %w[openid email profile], %w[openid profile] ], providers.map { _1.fetch(:scope) }
+  end
+
+  test "uses provider_name when supplied" do
+    providers = OidcConfiguration.providers(
+      env: base_env.merge(
+        "OIDC_PROVIDERS" => "keycloak",
+        "OIDC_KEYCLOAK_ISSUER" => "https://idp.example.test/realms/campfire",
+        "OIDC_KEYCLOAK_CLIENT_ID" => "campfire",
+        "OIDC_KEYCLOAK_CLIENT_SECRET" => "secret",
+        "OIDC_KEYCLOAK_REDIRECT_URI" => "https://chat.example.test/auth/oidc/callback",
+        "OIDC_KEYCLOAK_PROVIDER_NAME" => "BloxWeaver OIDC"
+      )
+    )
+
+    assert_equal [ "oidc" ], providers.map { _1.fetch(:strategy) }
+    assert_equal [ "BloxWeaver OIDC" ], providers.map { _1.fetch(:display_name) }
+  end
+
+  test "reads optional end-session endpoint" do
+    providers = OidcConfiguration.providers(
+      env: base_env.merge(
+        "OIDC_PROVIDERS" => "keycloak",
+        "OIDC_KEYCLOAK_ISSUER" => "https://idp.example.test/realms/campfire",
+        "OIDC_KEYCLOAK_CLIENT_ID" => "campfire",
+        "OIDC_KEYCLOAK_CLIENT_SECRET" => "secret",
+        "OIDC_KEYCLOAK_REDIRECT_URI" => "https://chat.example.test/auth/oidc/callback",
+        "OIDC_KEYCLOAK_END_SESSION_ENDPOINT" => "https://idp.example.test/logout"
+      )
+    )
+
+    assert_equal "https://idp.example.test/logout", providers.first.fetch(:end_session_endpoint)
+  end
+
+  test "raises when provider key is invalid" do
+    error = assert_raises ArgumentError do
+      OidcConfiguration.providers(env: base_env.merge("OIDC_PROVIDERS" => "Google-SSO"))
+    end
+
+    assert_match "Invalid OIDC provider key", error.message
+  end
+
+  test "raises when provider key is duplicated" do
+    error = assert_raises ArgumentError do
+      OidcConfiguration.providers(env: base_env.merge("OIDC_PROVIDERS" => "google,google"))
+    end
+
+    assert_match "Duplicate OIDC provider keys", error.message
+  end
+
+  test "raises when a required provider setting is missing" do
+    env = base_env.merge("OIDC_PROVIDERS" => "google")
+    env.delete("OIDC_GOOGLE_CLIENT_SECRET")
+
+    error = assert_raises ArgumentError do
+      OidcConfiguration.providers(env:)
+    end
+
+    assert_match "OIDC_GOOGLE_CLIENT_SECRET is required", error.message
+  end
+
+  test "raises when redirect uri callback path is invalid" do
+    env = base_env.merge("OIDC_PROVIDERS" => "google", "OIDC_GOOGLE_REDIRECT_URI" => "https://chat.example.test/callback")
+
+    error = assert_raises ArgumentError do
+      OidcConfiguration.providers(env:)
+    end
+
+    assert_match "must use /auth/<provider>/callback", error.message
+  end
+
+  test "raises when redirect uris map to duplicate strategy names" do
+    env = base_env.merge(
+      "OIDC_PROVIDERS" => "google,azure_ad",
+      "OIDC_GOOGLE_REDIRECT_URI" => "https://chat.example.test/auth/oidc/callback",
+      "OIDC_AZURE_AD_REDIRECT_URI" => "https://chat.example.test/auth/oidc/callback"
+    )
+
+    error = assert_raises ArgumentError do
+      OidcConfiguration.providers(env:)
+    end
+
+    assert_match "duplicate strategy names", error.message
+  end
+
+  private
+    def base_env
+      {
+        "OIDC_GOOGLE_ISSUER" => "https://accounts.google.com",
+        "OIDC_GOOGLE_CLIENT_ID" => "google-client-id",
+        "OIDC_GOOGLE_CLIENT_SECRET" => "google-client-secret",
+        "OIDC_GOOGLE_REDIRECT_URI" => "https://chat.example.test/auth/oidc_google/callback",
+        "OIDC_GOOGLE_SCOPE" => "openid email profile",
+        "OIDC_AZURE_AD_ISSUER" => "https://login.microsoftonline.com/example/v2.0",
+        "OIDC_AZURE_AD_CLIENT_ID" => "azure-client-id",
+        "OIDC_AZURE_AD_CLIENT_SECRET" => "azure-client-secret",
+        "OIDC_AZURE_AD_REDIRECT_URI" => "https://chat.example.test/auth/oidc_azure_ad/callback",
+        "OIDC_AZURE_AD_SCOPE" => "openid,profile"
+      }
+    end
+end

--- a/test/models/oidc_logout_test.rb
+++ b/test/models/oidc_logout_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class OidcLogoutTest < ActiveSupport::TestCase
+  test "returns nil when provider strategy is unknown" do
+    assert_nil OidcLogout.logout_url_for(
+      strategy: "missing",
+      post_logout_redirect_uri: "https://chat.example.test/",
+      env: {}
+    )
+  end
+
+  test "builds logout URL from configured end-session endpoint" do
+    env = base_env.merge(
+      "OIDC_PROVIDERS" => "keycloak",
+      "OIDC_KEYCLOAK_END_SESSION_ENDPOINT" => "https://idp.example.test/logout"
+    )
+
+    logout_url = OidcLogout.logout_url_for(
+      strategy: "oidc",
+      post_logout_redirect_uri: "https://chat.example.test/",
+      env: env
+    )
+
+    uri = URI.parse(logout_url)
+    params = Rack::Utils.parse_nested_query(uri.query)
+
+    assert_equal "https://idp.example.test/logout", "#{uri.scheme}://#{uri.host}#{uri.path}"
+    assert_equal "campfire", params["client_id"]
+    assert_equal "https://chat.example.test/", params["post_logout_redirect_uri"]
+  end
+
+  test "adds id_token_hint when provided" do
+    env = base_env.merge(
+      "OIDC_PROVIDERS" => "keycloak",
+      "OIDC_KEYCLOAK_END_SESSION_ENDPOINT" => "https://idp.example.test/logout"
+    )
+
+    logout_url = OidcLogout.logout_url_for(
+      strategy: "oidc",
+      id_token_hint: "jwt-id-token",
+      post_logout_redirect_uri: "https://chat.example.test/",
+      env: env
+    )
+
+    params = Rack::Utils.parse_nested_query(URI.parse(logout_url).query)
+    assert_equal "jwt-id-token", params["id_token_hint"]
+  end
+
+  test "discovers end-session endpoint from issuer metadata when not configured" do
+    stub_request(:get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { end_session_endpoint: "https://idp.example.test/discovered-logout?foo=bar" }.to_json
+      )
+
+    logout_url = OidcLogout.logout_url_for(
+      strategy: "oidc",
+      post_logout_redirect_uri: "https://chat.example.test/",
+      env: base_env.merge("OIDC_PROVIDERS" => "keycloak")
+    )
+
+    uri = URI.parse(logout_url)
+    params = Rack::Utils.parse_nested_query(uri.query)
+
+    assert_equal "https://idp.example.test/discovered-logout", "#{uri.scheme}://#{uri.host}#{uri.path}"
+    assert_equal "bar", params["foo"]
+    assert_equal "campfire", params["client_id"]
+    assert_equal "https://chat.example.test/", params["post_logout_redirect_uri"]
+  end
+
+  private
+    def base_env
+      {
+        "OIDC_KEYCLOAK_ISSUER" => "https://idp.example.test/realms/campfire",
+        "OIDC_KEYCLOAK_CLIENT_ID" => "campfire",
+        "OIDC_KEYCLOAK_CLIENT_SECRET" => "secret",
+        "OIDC_KEYCLOAK_REDIRECT_URI" => "https://chat.example.test/auth/oidc/callback"
+      }
+    end
+end

--- a/test/models/oidc_logout_test.rb
+++ b/test/models/oidc_logout_test.rb
@@ -29,6 +29,19 @@ class OidcLogoutTest < ActiveSupport::TestCase
     assert_equal "https://chat.example.test/", params["post_logout_redirect_uri"]
   end
 
+  test "ignores non-https configured end-session endpoint" do
+    env = base_env.merge(
+      "OIDC_PROVIDERS" => "keycloak",
+      "OIDC_KEYCLOAK_END_SESSION_ENDPOINT" => "http://idp.example.test/logout"
+    )
+
+    assert_nil OidcLogout.logout_url_for(
+      strategy: "oidc",
+      post_logout_redirect_uri: "https://chat.example.test/",
+      env: env
+    )
+  end
+
   test "adds id_token_hint when provided" do
     env = base_env.merge(
       "OIDC_PROVIDERS" => "keycloak",
@@ -47,29 +60,77 @@ class OidcLogoutTest < ActiveSupport::TestCase
   end
 
   test "discovers end-session endpoint from issuer metadata when not configured" do
-    stub_request(:get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration")
-      .to_return(
-        status: 200,
-        headers: { "Content-Type" => "application/json" },
-        body: { end_session_endpoint: "https://idp.example.test/discovered-logout?foo=bar" }.to_json
+    with_memory_cache do
+      stub_request(:get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { end_session_endpoint: "https://idp.example.test/discovered-logout?foo=bar" }.to_json
+        )
+
+      logout_url = OidcLogout.logout_url_for(
+        strategy: "oidc",
+        post_logout_redirect_uri: "https://chat.example.test/",
+        env: base_env.merge("OIDC_PROVIDERS" => "keycloak")
       )
 
-    logout_url = OidcLogout.logout_url_for(
-      strategy: "oidc",
-      post_logout_redirect_uri: "https://chat.example.test/",
-      env: base_env.merge("OIDC_PROVIDERS" => "keycloak")
-    )
+      uri = URI.parse(logout_url)
+      params = Rack::Utils.parse_nested_query(uri.query)
 
-    uri = URI.parse(logout_url)
-    params = Rack::Utils.parse_nested_query(uri.query)
+      assert_equal "https://idp.example.test/discovered-logout", "#{uri.scheme}://#{uri.host}#{uri.path}"
+      assert_equal "bar", params["foo"]
+      assert_equal "campfire", params["client_id"]
+      assert_equal "https://chat.example.test/", params["post_logout_redirect_uri"]
+    end
+  end
 
-    assert_equal "https://idp.example.test/discovered-logout", "#{uri.scheme}://#{uri.host}#{uri.path}"
-    assert_equal "bar", params["foo"]
-    assert_equal "campfire", params["client_id"]
-    assert_equal "https://chat.example.test/", params["post_logout_redirect_uri"]
+  test "ignores discovered end-session endpoint when host differs from issuer host" do
+    with_memory_cache do
+      stub_request(:get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { end_session_endpoint: "https://evil.example.test/discovered-logout" }.to_json
+        )
+
+      assert_nil OidcLogout.logout_url_for(
+        strategy: "oidc",
+        post_logout_redirect_uri: "https://chat.example.test/",
+        env: base_env.merge("OIDC_PROVIDERS" => "keycloak")
+      )
+    end
+  end
+
+  test "caches discovery metadata per issuer" do
+    with_memory_cache do
+      stub_request(:get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { end_session_endpoint: "https://idp.example.test/discovered-logout" }.to_json
+        )
+
+      2.times do
+        OidcLogout.logout_url_for(
+          strategy: "oidc",
+          post_logout_redirect_uri: "https://chat.example.test/",
+          env: base_env.merge("OIDC_PROVIDERS" => "keycloak")
+        )
+      end
+
+      assert_requested :get, "https://idp.example.test/realms/campfire/.well-known/openid-configuration", times: 1
+    end
   end
 
   private
+    def with_memory_cache
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      yield
+    ensure
+      Rails.cache = original_cache
+    end
+
     def base_env
       {
         "OIDC_KEYCLOAK_ISSUER" => "https://idp.example.test/realms/campfire",

--- a/test/models/sso_authentication_test.rb
+++ b/test/models/sso_authentication_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class SsoAuthenticationTest < ActiveSupport::TestCase
+  include SsoTestHelper
+
+  setup do
+    @auth = OmniAuth::AuthHash.new(
+      provider: "oidc",
+      uid: "unique-idp-id-123",
+      info: OmniAuth::AuthHash::InfoHash.new(
+        email: "newuser@example.com",
+        name: "New User"
+      )
+    )
+  end
+
+  test "finds existing user by SSO identity" do
+    user = users(:jz)
+    user.update!(sso_provider: "oidc", sso_uid: "unique-idp-id-123")
+
+    @auth.info.email = user.email_address
+
+    result = SsoAuthentication.find_or_create_user_from(@auth)
+    assert_equal user, result
+  end
+
+  test "links existing user by email on first SSO login" do
+    user = users(:jz)
+    @auth.info.email = user.email_address
+
+    assert_nil user.sso_provider
+
+    result = SsoAuthentication.find_or_create_user_from(@auth)
+
+    assert_equal user, result
+    assert_equal "oidc", result.reload.sso_provider
+    assert_equal "unique-idp-id-123", result.sso_uid
+  end
+
+  test "auto-creates new user when no match found" do
+    assert_difference -> { User.count }, +1 do
+      user = SsoAuthentication.find_or_create_user_from(@auth)
+
+      assert_equal "New User", user.name
+      assert_equal "newuser@example.com", user.email_address
+      assert_equal "oidc", user.sso_provider
+      assert_equal "unique-idp-id-123", user.sso_uid
+      assert user.member?
+      assert user.active?
+    end
+  end
+
+  test "auto-created user has no password" do
+    user = SsoAuthentication.find_or_create_user_from(@auth)
+    assert_nil user.password_digest
+  end
+
+  test "auto-created user gets membership to open rooms" do
+    user = SsoAuthentication.find_or_create_user_from(@auth)
+    assert user.rooms.any?
+  end
+
+  test "falls back to email prefix when name is blank" do
+    auth = OmniAuth::AuthHash.new(
+      provider: "oidc",
+      uid: "unique-idp-id-456",
+      info: { email: "newuser@example.com" }
+    )
+
+    user = SsoAuthentication.find_or_create_user_from(auth)
+    assert_equal "newuser", user.name
+  end
+
+  test "raises error when email is missing" do
+    @auth.info.email = nil
+
+    assert_raises SsoAuthentication::Error, "No email provided by identity provider" do
+      SsoAuthentication.find_or_create_user_from(@auth)
+    end
+  end
+
+  test "raises error when UID is missing" do
+    @auth.uid = ""
+
+    assert_raises SsoAuthentication::Error, "No UID provided by identity provider" do
+      SsoAuthentication.find_or_create_user_from(@auth)
+    end
+  end
+
+  test "normalizes email to lowercase" do
+    user = users(:jz)
+    @auth.info.email = user.email_address.upcase
+
+    result = SsoAuthentication.find_or_create_user_from(@auth)
+    assert_equal user, result
+  end
+
+  test "uses uid as email fallback when uid is an email address" do
+    @auth.provider = "oidc"
+    @auth.uid = "uid-email@example.com"
+    @auth.info.email = nil
+
+    user = SsoAuthentication.find_or_create_user_from(@auth)
+    assert_equal "uid-email@example.com", user.email_address
+  end
+
+  test "uses raw_info mail attribute as email fallback" do
+    @auth.provider = "oidc"
+    @auth.info.email = nil
+    @auth.extra = OmniAuth::AuthHash.new(raw_info: { "mail" => "raw-mail@example.com" })
+
+    user = SsoAuthentication.find_or_create_user_from(@auth)
+    assert_equal "raw-mail@example.com", user.email_address
+  end
+end

--- a/test/models/sso_authentication_test.rb
+++ b/test/models/sso_authentication_test.rb
@@ -89,10 +89,30 @@ class SsoAuthenticationTest < ActiveSupport::TestCase
 
   test "normalizes email to lowercase" do
     user = users(:jz)
-    @auth.info.email = user.email_address.upcase
+    user.update!(email_address: "JZ@37signals.com")
+    @auth.info.email = user.email_address.downcase
 
     result = SsoAuthentication.find_or_create_user_from(@auth)
     assert_equal user, result
+  end
+
+  test "rejects linking when the identity provider marks email as unverified" do
+    user = users(:jz)
+    @auth.info.email = user.email_address
+    @auth.extra = OmniAuth::AuthHash.new(raw_info: { "email_verified" => false })
+
+    assert_raises SsoAuthentication::Error, "Identity provider did not verify the email address" do
+      SsoAuthentication.find_or_create_user_from(@auth)
+    end
+  end
+
+  test "rejects linking by email when the existing account is already SSO-linked" do
+    user = users(:sso_user)
+    @auth.info.email = user.email_address
+
+    assert_raises SsoAuthentication::Error, "Email is already linked to another SSO account" do
+      SsoAuthentication.find_or_create_user_from(@auth)
+    end
   end
 
   test "uses uid as email fallback when uid is an email address" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require "turbo/broadcastable/test_helper"
 WebMock.enable!
 
 class ActiveSupport::TestCase
+  ENV_MUTEX = Mutex.new
+
   include ActiveJob::TestHelper
 
   parallelize(workers: :number_of_processors)
@@ -33,5 +35,21 @@ class ActiveSupport::TestCase
 
   teardown do
     WebMock.reset!
+  end
+
+  def with_env(overrides)
+    ENV_MUTEX.synchronize do
+      original_values = overrides.to_h { |key, _| [ key, ENV[key] ] }
+
+      overrides.each do |key, value|
+        value.nil? ? ENV.delete(key) : ENV[key] = value
+      end
+
+      yield
+    ensure
+      original_values.each do |key, value|
+        value.nil? ? ENV.delete(key) : ENV[key] = value
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  include SessionTestHelper, MentionTestHelper, TurboTestHelper
+  include SessionTestHelper, MentionTestHelper, TurboTestHelper, SsoTestHelper
 
   setup do
     ActionCable.server.pubsub.clear

--- a/test/test_helpers/sso_test_helper.rb
+++ b/test/test_helpers/sso_test_helper.rb
@@ -1,0 +1,25 @@
+module SsoTestHelper
+  def set_omniauth_auth(provider:, uid:, email:, name: "Test User", id_token: nil)
+    auth_hash = OmniAuth::AuthHash.new(
+      provider: provider.to_s,
+      uid: uid,
+      info: OmniAuth::AuthHash::InfoHash.new(
+        email: email,
+        name: name
+      ),
+      credentials: OmniAuth::AuthHash.new(
+        id_token: id_token
+      )
+    )
+
+    Rails.application.env_config["omniauth.auth"] = auth_hash
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[provider.to_sym] = auth_hash
+  end
+
+  def clear_omniauth_auth
+    Rails.application.env_config.delete("omniauth.auth")
+    OmniAuth.config.mock_auth.clear
+    OmniAuth.config.test_mode = false
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds OpenID Connect (OIDC) Single Sign-On (SSO) support to Campfire, including multi-provider configuration, SSO login/callback handling, automatic user linking/creation, and OIDC-aware logout. It also introduces an SSO-first onboarding mode when password registration is disabled.

## What Changed

- Added OIDC dependencies and OmniAuth setup:
  - `omniauth`
  - `omniauth-rails_csrf_protection`
  - `omniauth_openid_connect`
  - New initializer to register providers from environment config.
- Added OIDC provider configuration service (`OidcConfiguration`):
  - Supports multiple providers via `OIDC_PROVIDERS`.
  - Validates required env vars, provider key format, and callback-derived strategy names.
- Added SSO authentication/session flow:
  - New `SsoSessionsController` for `/auth/:provider/callback` and `/auth/failure`.
  - New `SsoAuthentication` service to:
    - Find existing users by `sso_provider/sso_uid`.
    - Link existing users by email on first SSO login.
    - Auto-create users when no match exists.
- Added OIDC logout support:
  - New `OidcLogout` service to build RP-initiated logout URLs.
  - Uses configured `END_SESSION_ENDPOINT` or issuer discovery metadata.
  - `SessionsController#destroy` now redirects through provider logout when available.
- Added SSO room invite onboarding:
  - New signed room invite token (`Room#sso_invite_token`) and lookup.
  - First SSO login from invite URL auto-grants membership to that room.
  - Added SSO invite partial and integrated it in account/room invitation UI.
- Updated auth/account behavior:
  - Added `DISABLE_PASSWORD_REGISTRATION` handling to join flow.
  - SSO users cannot edit name/email in profile; password edit is constrained by registration mode.
  - Login page now supports SSO-first and mixed auth layouts.
- Database changes:
  - `users`: add `sso_provider`, `sso_uid`, unique partial index on both.
  - `sessions`: add `sso_provider`, `oidc_id_token`.
- Docs/dev setup:
  - README updated with full OIDC/SSO configuration and examples.
  - Added `compose.yml` for local Docker Compose flow.

## Validation

Ran targeted SSO/auth test suite successfully:

```bash
PARALLEL_WORKERS=1 bin/rails test test/controllers/sso_sessions_controller_test.rb test/controllers/sessions_controller_test.rb test/controllers/users_controller_test.rb test/controllers/users/profiles_controller_test.rb test/models/sso_authentication_test.rb test/models/oidc_configuration_test.rb test/models/oidc_logout_test.rb
```

Result: **59 runs, 162 assertions, 0 failures, 0 errors, 0 skips**.
