### PR TITLE
Add presence tracking and typing indicators

### DIFF
--- a/app/assets/stylesheets/avatars.css
+++ b/app/assets/stylesheets/avatars.css
@@ -39,6 +39,30 @@
   }
 }
 
+.avatar--presence {
+  &::before {
+    --presence-size: max(0.72em, 8px);
+
+    aspect-ratio: 1;
+    border: 2px solid var(--color-bg);
+    border-radius: 999px;
+    content: "";
+    inline-size: var(--presence-size);
+    inset: auto 0 0 auto;
+    position: absolute;
+    transform: translate(10%, 10%);
+    z-index: 1;
+  }
+}
+
+.avatar--online::before {
+  background-color: var(--color-positive);
+}
+
+.avatar--offline::before {
+  background-color: var(--color-border-darker);
+}
+
 .avatar--icon {
   border: 1px solid var(--color-border-darker);
   background-color: var(--color-text-reversed);

--- a/app/assets/stylesheets/avatars.css
+++ b/app/assets/stylesheets/avatars.css
@@ -40,19 +40,21 @@
 }
 
 .avatar--presence {
-  &::before {
-    --presence-size: max(0.72em, 8px);
+  position: relative;
+}
 
-    aspect-ratio: 1;
-    border: 2px solid var(--color-bg);
-    border-radius: 999px;
-    content: "";
-    inline-size: var(--presence-size);
-    inset: auto 0 0 auto;
-    position: absolute;
-    transform: translate(10%, 10%);
-    z-index: 1;
-  }
+.avatar--presence::before {
+  --presence-size: max(0.72em, 8px);
+
+  aspect-ratio: 1;
+  border: 2px solid var(--color-bg);
+  border-radius: 999px;
+  content: "";
+  inline-size: var(--presence-size);
+  inset: auto 0 0 auto;
+  position: absolute;
+  transform: translate(10%, 10%);
+  z-index: 1;
 }
 
 .avatar--online::before {

--- a/app/assets/stylesheets/sidebar.css
+++ b/app/assets/stylesheets/sidebar.css
@@ -192,6 +192,13 @@
   }
 }
 
+.direct__presence {
+  color: var(--color-border-darker);
+  line-height: 1;
+  margin-block-start: 0.15rem;
+  text-transform: lowercase;
+}
+
 /* Rooms */
 .rooms {
   --column-gap: 0.5em;

--- a/app/channels/presence_channel.rb
+++ b/app/channels/presence_channel.rb
@@ -31,15 +31,18 @@ class PresenceChannel < RoomChannel
     end
 
     def broadcast_direct_room_presence
-      direct_room_memberships_for_current_user.each do |direct_room_membership|
-        direct_room = direct_room_membership.room
+      direct_room_ids = direct_room_ids_for_current_user
+      return if direct_room_ids.empty?
 
-        direct_room.memberships.includes(:room, :user).find_each do |room_membership|
-          room_membership.broadcast_replace_to room_membership.user, :rooms,
-            target: [ direct_room, :list ],
-            partial: "users/sidebars/rooms/direct",
-            locals: { membership: room_membership }
-        end
+      direct_room_memberships = Membership.where(room_id: direct_room_ids).includes(:user, :room)
+      direct_user_ids = direct_room_memberships.map(&:user_id).uniq
+      online_user_lookup = Membership.online_user_lookup(direct_user_ids)
+
+      direct_room_memberships.each do |room_membership|
+        room_membership.broadcast_replace_to room_membership.user, :rooms,
+          target: [ room_membership.room, :list ],
+          partial: "users/sidebars/rooms/direct",
+          locals: { membership: room_membership, online_user_lookup: online_user_lookup }
       end
     end
 
@@ -51,10 +54,11 @@ class PresenceChannel < RoomChannel
       current_user.slice(:id, :name)
     end
 
-    def direct_room_memberships_for_current_user
+    def direct_room_ids_for_current_user
       current_user.memberships
         .joins(:room)
         .merge(Room.directs)
-        .includes(room: :memberships)
+        .distinct
+        .pluck(:room_id)
     end
 end

--- a/app/channels/presence_channel.rb
+++ b/app/channels/presence_channel.rb
@@ -35,7 +35,7 @@ class PresenceChannel < RoomChannel
       return if direct_room_ids.empty?
 
       direct_room_membership_scope = Membership.where(room_id: direct_room_ids)
-      direct_room_memberships = direct_room_membership_scope.includes(:user, :room)
+      direct_room_memberships = direct_room_membership_scope.includes(:user, room: :users)
       direct_user_ids = direct_room_membership_scope.distinct.pluck(:user_id)
       online_user_lookup = Membership.online_user_lookup(direct_user_ids)
 

--- a/app/channels/presence_channel.rb
+++ b/app/channels/presence_channel.rb
@@ -5,11 +5,16 @@ class PresenceChannel < RoomChannel
   def present
     membership.present
 
+    broadcast_presence(:present)
+    broadcast_direct_room_presence
     broadcast_read_room
   end
 
   def absent
     membership.disconnected
+
+    broadcast_presence(:absent)
+    broadcast_direct_room_presence
   end
 
   def refresh
@@ -21,7 +26,35 @@ class PresenceChannel < RoomChannel
       @room.memberships.find_by(user: current_user)
     end
 
+    def broadcast_presence(action)
+      broadcast_to @room, action:, user: current_user_attributes
+    end
+
+    def broadcast_direct_room_presence
+      direct_room_memberships_for_current_user.each do |direct_room_membership|
+        direct_room = direct_room_membership.room
+
+        direct_room.memberships.includes(:room, :user).find_each do |room_membership|
+          room_membership.broadcast_replace_to room_membership.user, :rooms,
+            target: [ direct_room, :list ],
+            partial: "users/sidebars/rooms/direct",
+            locals: { membership: room_membership }
+        end
+      end
+    end
+
     def broadcast_read_room
       ActionCable.server.broadcast "user_#{current_user.id}_reads", { room_id: membership.room_id }
+    end
+
+    def current_user_attributes
+      current_user.slice(:id, :name)
+    end
+
+    def direct_room_memberships_for_current_user
+      current_user.memberships
+        .joins(:room)
+        .merge(Room.directs)
+        .includes(room: :memberships)
     end
 end

--- a/app/channels/presence_channel.rb
+++ b/app/channels/presence_channel.rb
@@ -34,8 +34,9 @@ class PresenceChannel < RoomChannel
       direct_room_ids = direct_room_ids_for_current_user
       return if direct_room_ids.empty?
 
-      direct_room_memberships = Membership.where(room_id: direct_room_ids).includes(:user, :room)
-      direct_user_ids = direct_room_memberships.map(&:user_id).uniq
+      direct_room_membership_scope = Membership.where(room_id: direct_room_ids)
+      direct_room_memberships = direct_room_membership_scope.includes(:user, :room)
+      direct_user_ids = direct_room_membership_scope.distinct.pluck(:user_id)
       online_user_lookup = Membership.online_user_lookup(direct_user_ids)
 
       direct_room_memberships.each do |room_membership|

--- a/app/controllers/rooms/directs_controller.rb
+++ b/app/controllers/rooms/directs_controller.rb
@@ -24,7 +24,7 @@ class Rooms::DirectsController < RoomsController
     end
 
     def broadcast_create_room(room)
-      online_user_lookup = Membership.online_user_lookup(room.memberships.map(&:user_id))
+      online_user_lookup = Membership.online_user_lookup(room.memberships.pluck(:user_id))
 
       room.memberships.each do |membership|
         membership.broadcast_prepend_to membership.user, :rooms, target: :direct_rooms, partial: "users/sidebars/rooms/direct",

--- a/app/controllers/rooms/directs_controller.rb
+++ b/app/controllers/rooms/directs_controller.rb
@@ -24,8 +24,11 @@ class Rooms::DirectsController < RoomsController
     end
 
     def broadcast_create_room(room)
+      online_user_lookup = Membership.online_user_lookup(room.memberships.map(&:user_id))
+
       room.memberships.each do |membership|
-        membership.broadcast_prepend_to membership.user, :rooms, target: :direct_rooms, partial: "users/sidebars/rooms/direct"
+        membership.broadcast_prepend_to membership.user, :rooms, target: :direct_rooms, partial: "users/sidebars/rooms/direct",
+          locals: { membership: membership, online_user_lookup: online_user_lookup }
       end
     end
 

--- a/app/controllers/users/sidebars_controller.rb
+++ b/app/controllers/users/sidebars_controller.rb
@@ -16,7 +16,7 @@ class Users::SidebarsController < ApplicationController
 
     def find_direct_placeholder_users
       exclude_user_ids = user_ids_already_in_direct_rooms_with_current_user.including(Current.user.id)
-      User.active.where.not(id: exclude_user_ids).order(:created_at).limit([DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0].max)
+      User.active.where.not(id: exclude_user_ids).order(:created_at).limit([ DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0 ].max)
     end
 
     def user_ids_already_in_direct_rooms_with_current_user

--- a/app/controllers/users/sidebars_controller.rb
+++ b/app/controllers/users/sidebars_controller.rb
@@ -5,8 +5,10 @@ class Users::SidebarsController < ApplicationController
     all_memberships     = Current.user.memberships.visible.with_ordered_room
     @direct_memberships = extract_direct_memberships(all_memberships)
     @other_memberships  = all_memberships.without(@direct_memberships)
+    direct_user_ids = user_ids_already_in_direct_rooms_with_current_user
+    @direct_online_user_lookup = Membership.online_user_lookup(direct_user_ids)
 
-    @direct_placeholder_users = find_direct_placeholder_users
+    @direct_placeholder_users = find_direct_placeholder_users(direct_user_ids)
   end
 
   private
@@ -14,8 +16,8 @@ class Users::SidebarsController < ApplicationController
       all_memberships.select { |m| m.room.direct? }.sort_by { |m| m.room.updated_at }.reverse
     end
 
-    def find_direct_placeholder_users
-      exclude_user_ids = user_ids_already_in_direct_rooms_with_current_user.including(Current.user.id)
+    def find_direct_placeholder_users(direct_user_ids)
+      exclude_user_ids = direct_user_ids.including(Current.user.id)
       User.active.where.not(id: exclude_user_ids).order(:created_at).limit([ DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0 ].max)
     end
 

--- a/app/javascript/models/typing_tracker.js
+++ b/app/javascript/models/typing_tracker.js
@@ -27,7 +27,7 @@ export default class TypingTracker {
     const names = Object.keys(this.currentlyTyping).sort()
 
     if (names.length > 0) {
-      this.callback(`${names.join(", ")}`)
+      this.callback(this.#typingMessage(names))
     } else {
       this.callback(null)
     }
@@ -38,5 +38,17 @@ export default class TypingTracker {
     this.currentlyTyping = Object.fromEntries(
       Object.entries(this.currentlyTyping).filter(([_name, timestamp]) => timestamp > cutoff)
    )
+  }
+
+  #typingMessage(names) {
+    if (names.length === 1) {
+      return `${names[0]} is typing...`
+    }
+
+    if (names.length === 2) {
+      return `${names[0]} and ${names[1]} are typing...`
+    }
+
+    return `${names[0]}, ${names[1]}, and ${names.length - 2} others are typing...`
   }
 }

--- a/app/javascript/models/typing_tracker.js
+++ b/app/javascript/models/typing_tracker.js
@@ -49,6 +49,9 @@ export default class TypingTracker {
       return `${names[0]} and ${names[1]} are typing...`
     }
 
-    return `${names[0]}, ${names[1]}, and ${names.length - 2} others are typing...`
+    const otherCount = names.length - 2
+    const otherLabel = otherCount === 1 ? 'other' : 'others'
+
+    return `${names[0]}, ${names[1]}, and ${otherCount} ${otherLabel} are typing...`
   }
 }

--- a/app/javascript/models/typing_tracker.js
+++ b/app/javascript/models/typing_tracker.js
@@ -50,7 +50,7 @@ export default class TypingTracker {
     }
 
     const otherCount = names.length - 2
-    const otherLabel = otherCount === 1 ? 'other' : 'others'
+    const otherLabel = otherCount === 1 ? "other" : "others"
 
     return `${names[0]}, ${names[1]}, and ${otherCount} ${otherLabel} are typing...`
   }

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,6 +14,13 @@ class Membership < ApplicationRecord
   scope :visible, -> { where.not(involvement: :invisible) }
   scope :unread,  -> { where.not(unread_at: nil) }
 
+  def self.online_user_lookup(user_ids = nil)
+    relation = connected.distinct
+    relation = relation.where(user_id: user_ids) if user_ids
+
+    relation.pluck(:user_id).index_with(true)
+  end
+
   def read
     update!(unread_at: nil)
   end

--- a/app/views/rooms/show/_composer.html.erb
+++ b/app/views/rooms/show/_composer.html.erb
@@ -51,7 +51,8 @@
           </div>
         </fieldset>
 
-        <div class="typing-indicator gap txt-small align-center flex-inline" data-typing-notifications-target="indicator">
+        <div class="typing-indicator gap txt-small align-center flex-inline" data-typing-notifications-target="indicator"
+            aria-live="polite" aria-atomic="true">
           <div class="typing-indicator__author spinner" data-typing-notifications-target="author"></div>
         </div>
 

--- a/app/views/users/sidebars/rooms/_direct.html.erb
+++ b/app/views/users/sidebars/rooms/_direct.html.erb
@@ -1,13 +1,13 @@
 <% members = membership.room.users.without(membership.user).presence || [ membership.user ] %>
-<% member_ids = members.map(&:id) %>
-<% online_member_ids = Membership.connected.where(user_id: member_ids).distinct.pluck(:user_id) %>
+<% online_user_lookup = local_assigns.fetch(:online_user_lookup, {}) %>
+<% online_count = members.count { |member| online_user_lookup[member.id] } %>
 
 <%= link_to_room membership.room, class: [ "direct", "unread": membership.unread? ], id: dom_id(membership.room, :list),
       data: { sorted_list_number: membership.room.updated_at.to_fs(:epoch) } do %>
   <% if members.many? %>
     <div class="avatar__group">
       <% members.first(4).each do |member| %>
-        <% online = online_member_ids.include?(member.id) %>
+        <% online = online_user_lookup[member.id] %>
         <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
           <%= image_tag fresh_user_avatar_path(member), size: 20, aria: { hidden: "true" } %>
           <span class="for-screen-reader"><%= "#{member.name} is #{online ? "online" : "offline"}" %></span>
@@ -15,7 +15,7 @@
       <% end %>
     </div>
   <% else %>
-    <% online = online_member_ids.include?(members.first.id) %>
+    <% online = online_user_lookup[members.first.id] %>
     <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
       <%= image_tag fresh_user_avatar_path(members.first), size: 48, aria: { hidden: "true" } %>
       <span class="for-screen-reader"><%= "#{members.first.name} is #{online ? "online" : "offline"}" %></span>
@@ -35,9 +35,9 @@
 
   <span class="direct__presence txt-small" aria-hidden="true">
     <% if members.many? %>
-      <%= pluralize(online_member_ids.count, "online") %>
+      <%= pluralize(online_count, "online") %>
     <% else %>
-      <%= online_member_ids.any? ? "online" : "offline" %>
+      <%= online_count.positive? ? "online" : "offline" %>
     <% end %>
   </span>
 <% end %>

--- a/app/views/users/sidebars/rooms/_direct.html.erb
+++ b/app/views/users/sidebars/rooms/_direct.html.erb
@@ -1,13 +1,13 @@
 <% members = membership.room.users.without(membership.user).presence || [ membership.user ] %>
 <% online_user_lookup = local_assigns.fetch(:online_user_lookup, {}) %>
-<% online_count = members.count { |member| online_user_lookup[member.id] } %>
+<% online_count = members.count { |member| online_user_lookup[member.id] || member == membership.user } %>
 
 <%= link_to_room membership.room, class: [ "direct", "unread": membership.unread? ], id: dom_id(membership.room, :list),
       data: { sorted_list_number: membership.room.updated_at.to_fs(:epoch) } do %>
   <% if members.many? %>
     <div class="avatar__group">
       <% members.first(4).each do |member| %>
-        <% online = online_user_lookup[member.id] %>
+        <% online = online_user_lookup[member.id] || member == membership.user %>
         <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
           <%= image_tag fresh_user_avatar_path(member), size: 20, aria: { hidden: "true" } %>
           <span class="for-screen-reader"><%= "#{member.name} is #{online ? "online" : "offline"}" %></span>
@@ -15,7 +15,7 @@
       <% end %>
     </div>
   <% else %>
-    <% online = online_user_lookup[members.first.id] %>
+    <% online = online_user_lookup[members.first.id] || members.first == membership.user %>
     <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
       <%= image_tag fresh_user_avatar_path(members.first), size: 48, aria: { hidden: "true" } %>
       <span class="for-screen-reader"><%= "#{members.first.name} is #{online ? "online" : "offline"}" %></span>

--- a/app/views/users/sidebars/rooms/_direct.html.erb
+++ b/app/views/users/sidebars/rooms/_direct.html.erb
@@ -1,31 +1,43 @@
-<% cache membership do %>
-  <% members = membership.room.users.without(membership.user).presence || [ membership.user ] %>
+<% members = membership.room.users.without(membership.user).presence || [ membership.user ] %>
+<% member_ids = members.map(&:id) %>
+<% online_member_ids = Membership.connected.where(user_id: member_ids).distinct.pluck(:user_id) %>
 
-  <%= link_to_room membership.room, class: [ "direct", "unread": membership.unread? ], id: dom_id(membership.room, :list),
-        data: { sorted_list_number: membership.room.updated_at.to_fs(:epoch) } do %>
-    <% if members.many? %>
-      <div class="avatar__group">
-        <% members.first(4).each do |member| %>
-          <span class="avatar">
-            <%= image_tag fresh_user_avatar_path(member), size: 20, aria: { hidden: "true" } %>
-          </span>
-        <% end %>
-      </div>
-    <% else %>
-      <span class="avatar">
-        <%= image_tag fresh_user_avatar_path(members.first), size: 48, aria: { hidden: "true" } %>
-      </span>
-    <% end %>
-
-    <span class="direct__author flex align-center gap max-width min-width border-radius txt-small">
-      <span class="txt-nowrap overflow-ellipsis">
-        <span class="for-screen-reader">Ping with</span>
-        <% if members.many? %>
-          <%= members.map { |member| member.name.split(' ')[0, 3].map { |str| str[0].capitalize }.join }.to_sentence(two_words_connector: '+') %>
-        <% else %>
-          <%= members.first.name.split(' ')[0] %>
-        <% end %>
-      </span>
+<%= link_to_room membership.room, class: [ "direct", "unread": membership.unread? ], id: dom_id(membership.room, :list),
+      data: { sorted_list_number: membership.room.updated_at.to_fs(:epoch) } do %>
+  <% if members.many? %>
+    <div class="avatar__group">
+      <% members.first(4).each do |member| %>
+        <% online = online_member_ids.include?(member.id) %>
+        <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
+          <%= image_tag fresh_user_avatar_path(member), size: 20, aria: { hidden: "true" } %>
+          <span class="for-screen-reader"><%= "#{member.name} is #{online ? "online" : "offline"}" %></span>
+        </span>
+      <% end %>
+    </div>
+  <% else %>
+    <% online = online_member_ids.include?(members.first.id) %>
+    <span class="avatar avatar--presence <%= online ? "avatar--online" : "avatar--offline" %>">
+      <%= image_tag fresh_user_avatar_path(members.first), size: 48, aria: { hidden: "true" } %>
+      <span class="for-screen-reader"><%= "#{members.first.name} is #{online ? "online" : "offline"}" %></span>
     </span>
   <% end %>
+
+  <span class="direct__author flex align-center gap max-width min-width border-radius txt-small">
+    <span class="txt-nowrap overflow-ellipsis">
+      <span class="for-screen-reader">Ping with</span>
+      <% if members.many? %>
+        <%= members.map { |member| member.name.split(' ')[0, 3].map { |str| str[0].capitalize }.join }.to_sentence(two_words_connector: '+') %>
+      <% else %>
+        <%= members.first.name.split(' ')[0] %>
+      <% end %>
+    </span>
+  </span>
+
+  <span class="direct__presence txt-small" aria-hidden="true">
+    <% if members.many? %>
+      <%= pluralize(online_member_ids.count, "online") %>
+    <% else %>
+      <%= online_member_ids.any? ? "online" : "offline" %>
+    <% end %>
+  </span>
 <% end %>

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -20,7 +20,8 @@
         <% end %>
 
         <div id="direct_rooms" contents data-controller="sorted-list" data-action="rooms-list:unread@window->sorted-list#updateItem">
-          <%= render partial: "users/sidebars/rooms/direct", collection: @direct_memberships, as: :membership, cached: true %>
+          <%= render partial: "users/sidebars/rooms/direct", collection: @direct_memberships, as: :membership, cached: true,
+            locals: { online_user_lookup: @direct_online_user_lookup } %>
         </div>
 
         <div contents>

--- a/app/views/users/sidebars/show.html.erb
+++ b/app/views/users/sidebars/show.html.erb
@@ -20,7 +20,7 @@
         <% end %>
 
         <div id="direct_rooms" contents data-controller="sorted-list" data-action="rooms-list:unread@window->sorted-list#updateItem">
-          <%= render partial: "users/sidebars/rooms/direct", collection: @direct_memberships, as: :membership, cached: true,
+          <%= render partial: "users/sidebars/rooms/direct", collection: @direct_memberships, as: :membership,
             locals: { online_user_lookup: @direct_online_user_lookup } %>
         </div>
 

--- a/test/channels/presence_channel_test.rb
+++ b/test/channels/presence_channel_test.rb
@@ -48,4 +48,25 @@ class PresenceChannelTest < ActionCable::Channel::TestCase
       unsubscribe
     end
   end
+
+  test "subscribing to a direct room updates direct room entries for all room members" do
+    room = rooms(:david_and_jason)
+    jason_rooms_stream = Turbo::StreamsChannel.send(:stream_name_from, [ users(:jason), :rooms ])
+
+    assert_broadcasts jason_rooms_stream, 1 do
+      subscribe room_id: room.id
+    end
+  end
+
+  test "subscribing to any room updates direct room entries for direct chat members" do
+    room = rooms(:designers)
+    jason_rooms_stream = Turbo::StreamsChannel.send(:stream_name_from, [ users(:jason), :rooms ])
+    kevin_rooms_stream = Turbo::StreamsChannel.send(:stream_name_from, [ users(:kevin), :rooms ])
+
+    assert_broadcasts jason_rooms_stream, 1 do
+      assert_broadcasts kevin_rooms_stream, 1 do
+        subscribe room_id: room.id
+      end
+    end
+  end
 end

--- a/test/system/presence_indicators_test.rb
+++ b/test/system/presence_indicators_test.rb
@@ -1,0 +1,50 @@
+require "application_system_test_case"
+
+class PresenceIndicatorsTest < ApplicationSystemTestCase
+  test "shows online status in direct chats" do
+    room = rooms(:david_and_jason)
+
+    sign_in "david@37signals.com"
+    join_room room
+
+    assert_selector "##{dom_id(room, :list)} .avatar--offline", wait: 5
+
+    using_session("Jason") do
+      sign_in "jason@37signals.com"
+      join_room room
+    end
+
+    assert_selector "##{dom_id(room, :list)} .avatar--online", wait: 5
+  end
+
+  test "shows direct chat users online when they are active in another room" do
+    direct_room = rooms(:david_and_jason)
+
+    sign_in "david@37signals.com"
+    join_room direct_room
+    assert_selector "##{dom_id(direct_room, :list)} .avatar--offline", wait: 5
+
+    using_session("Jason") do
+      sign_in "jason@37signals.com"
+      join_room rooms(:designers)
+      fill_in_rich_text_area "message_body", with: "I am active here"
+    end
+
+    assert_selector "##{dom_id(direct_room, :list)} .avatar--online", wait: 5
+  end
+
+  test "shows typing indicator message" do
+    room = rooms(:designers)
+
+    sign_in "jz@37signals.com"
+    join_room room
+
+    using_session("Kevin") do
+      sign_in "kevin@37signals.com"
+      join_room room
+      fill_in_rich_text_area "message_body", with: "Drafting a response"
+    end
+
+    assert_selector "[data-typing-notifications-target='author']", text: "Kevin is typing...", wait: 5
+  end
+end

--- a/test/test_helpers/system_test_helper.rb
+++ b/test/test_helpers/system_test_helper.rb
@@ -2,7 +2,7 @@ module SystemTestHelper
   def sign_in(email_address, password = "secret123456")
     visit root_url
 
-    if page.has_no_field?("email_address", wait: 0) && page.has_css?("summary", text: "Sign in with email and password", wait: 0)
+    if page.has_css?("summary", text: "Sign in with email and password", wait: 1) && !page.has_field?("email_address", wait: 1)
       find("summary", text: "Sign in with email and password").click
     end
 

--- a/test/test_helpers/system_test_helper.rb
+++ b/test/test_helpers/system_test_helper.rb
@@ -2,6 +2,12 @@ module SystemTestHelper
   def sign_in(email_address, password = "secret123456")
     visit root_url
 
+    unless page.has_field?("email_address", wait: 2)
+      if page.has_css?("summary", text: "Sign in with email and password", wait: 2)
+        find("summary", text: "Sign in with email and password").click
+      end
+    end
+
     fill_in "email_address", with: email_address
     fill_in "password", with: password
 

--- a/test/test_helpers/system_test_helper.rb
+++ b/test/test_helpers/system_test_helper.rb
@@ -2,10 +2,8 @@ module SystemTestHelper
   def sign_in(email_address, password = "secret123456")
     visit root_url
 
-    unless page.has_field?("email_address", wait: 2)
-      if page.has_css?("summary", text: "Sign in with email and password", wait: 2)
-        find("summary", text: "Sign in with email and password").click
-      end
+    if page.has_no_field?("email_address", wait: 0) && page.has_css?("summary", text: "Sign in with email and password", wait: 0)
+      find("summary", text: "Sign in with email and password").click
     end
 
     fill_in "email_address", with: email_address


### PR DESCRIPTION
## Summary
Adds real-time presence tracking in direct chats and improves typing indicators.

When users connect/disconnect in any room, direct chat entries now refresh for all relevant members so avatar presence badges and online/offline labels stay current. Typing indicator text is also made human-readable and announced accessibly.

## Changes
- Broadcast presence updates from `PresenceChannel` on `present`/`absent`.
- Refresh direct-room sidebar entries for impacted users whenever a user’s presence changes.
- Add presence badges to direct chat avatars (`online`/`offline`) and show aggregate direct-room presence text (`online`, `offline`, or `N online`).
- Update typing indicator copy:
  - `Alice is typing...`
  - `Alice and Bob are typing...`
  - `Alice, Bob, and N others are typing...`
- Add `aria-live="polite"` and `aria-atomic="true"` for typing announcements.
- Add/extend tests for:
  - Presence channel broadcasts to direct-chat members.
  - System-level direct chat presence behavior.
  - System-level typing indicator message rendering.
- Harden system test sign-in helper to open the email/password form when collapsed.