### PR TITLE
Add Kamal 2 deployment scaffolding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,6 +35,7 @@
 /bin/deploy
 /bin/deploy-*
 /bin/release
+/.kamal
 
 # Ignore master.key (should be set in environment)
 /config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ app/assets/builds/*
 
 # Ignore our exported zipfiles
 /*.zip
+
+# Kamal — only `.kamal/secrets` (a reference-only file) is tracked. Anything
+# else under .kamal/ is transient deploy state (locks, bundles, host caches).
+/.kamal/*
+!/.kamal/secrets

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,0 +1,54 @@
+# Secrets referenced by config/deploy.yml.
+#
+# This file is committed. It must never contain raw secret values — only
+# references to environment variables, files, or a password manager. If you
+# need a raw value, put it in a real env or use `kamal secrets fetch`.
+#
+# Each line is shell-evaluated, so `$(...)` and `${VAR}` work.
+
+# --- Registry ---
+# Token used to pull (and optionally push) the image from GHCR.
+# Use a personal access token with at least `read:packages`.
+# `write:packages` is required if you also build & push from your machine.
+#
+#   export KAMAL_REGISTRY_PASSWORD=ghp_xxx
+#
+# Or pull from a password manager — examples are below.
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+
+# --- Rails ---
+# config/master.key decrypts config/credentials.yml.enc.
+RAILS_MASTER_KEY=$(cat config/master.key)
+
+# Generate once with: bin/rails secret
+# Then export before deploying:  export SECRET_KEY_BASE=<value>
+SECRET_KEY_BASE=$SECRET_KEY_BASE
+
+# --- Web Push (VAPID) ---
+# Generate the keypair once: ./script/admin/create-vapid-key
+# Then export both halves before deploying.
+VAPID_PUBLIC_KEY=$VAPID_PUBLIC_KEY
+VAPID_PRIVATE_KEY=$VAPID_PRIVATE_KEY
+
+# --- Optional: Sentry ---
+# Leave unset to disable error reporting in production.
+SENTRY_DSN=$SENTRY_DSN
+
+# --- Password manager examples (uncomment one block instead of the above) ---
+#
+# 1Password:
+#   SECRETS=$(kamal secrets fetch --adapter 1password --account my-account \
+#     --from MyVault/Campfire KAMAL_REGISTRY_PASSWORD SECRET_KEY_BASE \
+#       VAPID_PUBLIC_KEY VAPID_PRIVATE_KEY SENTRY_DSN)
+#   KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD $SECRETS)
+#   SECRET_KEY_BASE=$(kamal secrets extract SECRET_KEY_BASE $SECRETS)
+#   VAPID_PUBLIC_KEY=$(kamal secrets extract VAPID_PUBLIC_KEY $SECRETS)
+#   VAPID_PRIVATE_KEY=$(kamal secrets extract VAPID_PRIVATE_KEY $SECRETS)
+#   SENTRY_DSN=$(kamal secrets extract SENTRY_DSN $SECRETS)
+#
+# Bitwarden:
+#   SECRETS=$(kamal secrets fetch --adapter bitwarden --from Campfire \
+#     KAMAL_REGISTRY_PASSWORD SECRET_KEY_BASE ...)
+#
+# AWS Secrets Manager:
+#   SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager --from prod/campfire ...)

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,11 @@ group :development, :test do
   gem "brakeman", require: false
 end
 
+group :development do
+  # Deploy this application anywhere as a SSL-enabled Docker container with Kamal.
+  gem "kamal", require: false
+end
+
 group :test do
   gem "capybara"
   gem "mocha"

--- a/KAMAL.md
+++ b/KAMAL.md
@@ -1,0 +1,153 @@
+# Deploying Campfire with Kamal
+
+This repo ships with a [Kamal 2](https://kamal-deploy.org) configuration so you
+can run Campfire as a single-machine production deployment that's roughly
+equivalent to the `docker run …` command in the [README](README.md), but with
+zero-downtime rollouts, SSL via Let's Encrypt, and one-command rollback.
+
+The image used by Kamal is the same multi-arch container built and pushed to
+GitHub Container Registry by `.github/workflows/publish-image.yml`, so you do
+not have to build locally.
+
+---
+
+## 1. Prerequisites
+
+- **A target server** with Docker installed and ports 80 and 443 reachable from
+  the public internet. Kamal will install kamal-proxy on first run.
+- **An SSH key** that lets you `ssh root@SERVER` (or another user with sudo).
+- **A domain** whose A record points at the server. SSL provisioning fails
+  without DNS, so set this up first.
+- **A GHCR pull token** — a GitHub personal access token (classic) with the
+  `read:packages` scope. Save it as `KAMAL_REGISTRY_PASSWORD` in your shell.
+- **Ruby 3.4.5** locally (see `.ruby-version`) so you can run `bundle exec kamal`.
+- **Docker Desktop / Engine** locally (only required if you want to build
+  images on your machine; you can skip this and use the GHCR image directly).
+
+## 2. Install the gem
+
+The Gemfile already declares `kamal` in the `:development` group. Install it:
+
+```sh
+bundle install
+```
+
+That gives you `bundle exec kamal …`. Optional convenience: `bundle binstubs kamal`
+to get `bin/kamal`.
+
+## 3. Generate one-time secrets
+
+Generate these once, then keep them somewhere safe (password manager, env vars,
+or a CI secret store).
+
+```sh
+# Rails secret key base
+bin/rails secret
+
+# VAPID keypair for Web Push notifications
+./script/admin/create-vapid-key
+```
+
+You'll also need:
+
+- `RAILS_MASTER_KEY` — already in `config/master.key` (do not commit it).
+- `KAMAL_REGISTRY_PASSWORD` — a GHCR personal access token (see Prerequisites).
+- `SENTRY_DSN` — optional, only if you want error reporting.
+
+## 4. Fill in `config/deploy.yml`
+
+Open `config/deploy.yml` and replace the two placeholders:
+
+- `servers.web` → your server's IP or DNS name
+- `proxy.host` → the public domain (e.g. `chat.example.com`)
+
+If you forked to a different namespace, also update `image:` and
+`registry.username` accordingly.
+
+## 5. Provide secrets
+
+`.kamal/secrets` is committed, but it never holds raw values — only references
+to environment variables or a password manager. The simplest path is to export
+the variables in your shell before deploying:
+
+```sh
+export KAMAL_REGISTRY_PASSWORD=ghp_xxx
+export SECRET_KEY_BASE=...
+export VAPID_PUBLIC_KEY=...
+export VAPID_PRIVATE_KEY=...
+# Optional
+export SENTRY_DSN=...
+```
+
+If you'd rather pull from a password manager, see the commented examples at the
+bottom of `.kamal/secrets` (1Password, Bitwarden, AWS Secrets Manager).
+
+## 6. First-time setup
+
+```sh
+bundle exec kamal setup
+```
+
+This will, on the target server:
+
+1. Install Docker if missing.
+2. Boot the `kamal-proxy` container.
+3. Pull the Campfire image from GHCR.
+4. Create the `campfire_storage` volume and mount it at `/rails/storage`.
+5. Start the app, register it with the proxy, and obtain a Let's Encrypt cert.
+
+When it finishes, browse to `https://YOUR-DOMAIN` and Campfire will walk you
+through creating the admin account.
+
+## 7. Day-to-day commands
+
+```sh
+# Deploy the latest main (builds locally, pushes, rolls out with zero downtime)
+bundle exec kamal deploy
+
+# Deploy without rebuilding — pulls the existing image tag from GHCR
+bundle exec kamal deploy --skip-push
+
+# Stream logs
+bundle exec kamal app logs -f
+
+# Rails console on the server
+bundle exec kamal console
+# (alias of `kamal app exec --interactive --reuse "bin/rails console"`)
+
+# Shell into the running app container
+bundle exec kamal shell
+
+# Roll back to the previous version
+bundle exec kamal rollback
+```
+
+## SSL options
+
+`config/deploy.yml` defaults to letting **kamal-proxy** terminate SSL and sets
+`DISABLE_SSL=true` so Campfire's bundled Thruster speaks plain HTTP behind the
+proxy. This is the modern Kamal 2 path and gives you zero-downtime cert
+rotations.
+
+If you'd rather use Campfire's built-in Thruster + Let's Encrypt (matches the
+plain `docker run` instructions in the README):
+
+1. In `config/deploy.yml`, set `proxy: false`.
+2. Remove `DISABLE_SSL` and add `SSL_DOMAIN: your-domain` under `env.clear`.
+3. Map host ports: add `servers.web.options.publish: ["80:80", "443:443"]`.
+
+You lose Kamal's zero-downtime cutover with this mode, but the configuration is
+simpler and matches what the upstream README documents.
+
+## Sanity check before first deploy
+
+```sh
+# Verify the config parses and resolves placeholders
+bundle exec kamal config
+
+# Print the audit/permissions check against your server
+bundle exec kamal audit
+```
+
+Both should exit cleanly. If they don't, fix the reported issue before running
+`kamal setup`.

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,88 @@
+# Name of your application. Used to uniquely configure containers.
+service: campfire
+
+# Container image used by the app. Pre-built by .github/workflows/publish-image.yml
+# and pushed to GHCR. Change the registry/path if you fork to a different namespace.
+image: leegeng/once-campfire
+
+# Deploy to these servers. Replace with your host's public IP or DNS name.
+servers:
+  web:
+    - REPLACE_WITH_SERVER_IP
+
+# Kamal Proxy (kamal-proxy) terminates TLS and handles zero-downtime cutovers.
+# Set `host` to the domain that resolves to the server above. SSL provisioning
+# uses Let's Encrypt automatically once the DNS record is in place.
+#
+# Campfire's image ships with Thruster (the `thrust` wrapper around Puma), which
+# can also terminate SSL on its own. We disable that path here (DISABLE_SSL=1 in
+# env.clear below) and let kamal-proxy front the app on port 80 internally.
+proxy:
+  ssl: true
+  host: REPLACE_WITH_DOMAIN
+  app_port: 80
+  healthcheck:
+    path: /up
+    interval: 3
+    timeout: 30
+
+# Registry credentials. Using GitHub Container Registry (GHCR) so the prebuilt
+# image from publish-image.yml can be reused. To push from a local Kamal build,
+# the token needs `write:packages`; to only pull, `read:packages` is enough.
+registry:
+  server: ghcr.io
+  username: leegeng
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+# Inject env vars into the running container.
+#   secret -> read from .kamal/secrets (or the host env), never committed
+#   clear  -> committed in this file, safe to share
+env:
+  secret:
+    - RAILS_MASTER_KEY
+    - SECRET_KEY_BASE
+    - VAPID_PUBLIC_KEY
+    - VAPID_PRIVATE_KEY
+    - SENTRY_DSN
+  clear:
+    # Let kamal-proxy handle SSL; Thruster speaks plain HTTP on :80.
+    DISABLE_SSL: "true"
+    # Stream Rails logs to STDOUT so `kamal app logs` works without extra setup.
+    RAILS_LOG_TO_STDOUT: "true"
+    # Production defaults — adjust if your server has more CPU/RAM.
+    WEB_CONCURRENCY: "2"
+    RAILS_MAX_THREADS: "5"
+
+# Persist SQLite database, uploads, and Let's Encrypt state across container
+# restarts and redeploys. The image expects everything writable under /rails/storage.
+volumes:
+  - "campfire_storage:/rails/storage"
+
+# Build configuration. Skip if you only want to deploy the prebuilt GHCR image
+# (run `kamal deploy --skip-push` in that case).
+builder:
+  arch: amd64
+  # Uncomment to also build arm64 (slower locally, useful for ARM servers):
+  # arch:
+  #   - amd64
+  #   - arm64
+
+# Use accessory containers (Postgres, Redis, ...) here if you ever split storage
+# out of the single Campfire container. Not needed for the default setup —
+# Campfire bundles SQLite + Redis + Resque + Puma + Thruster in one image.
+# accessories:
+#   db:
+#     image: postgres:16
+#     ...
+
+# Run kamal commands as a non-root user on the target server.
+# ssh:
+#   user: deploy
+
+# Aliases for common one-off commands.
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"


### PR DESCRIPTION
## Summary
Stand up a Kamal-based single-machine deployment that reuses the GHCR image already produced by `.github/workflows/publish-image.yml`. After cloning, the path from zero to live is essentially:

1. Edit two placeholders in `config/deploy.yml` (server IP, domain)
2. Export a few secrets (`SECRET_KEY_BASE`, VAPID keypair, GHCR token)
3. `bundle exec kamal setup`

## What's added
- `Gemfile`: `kamal` gem under `:development`.
- `config/deploy.yml`: Kamal 2 config — GHCR registry, kamal-proxy for SSL termination, `/rails/storage` as a named volume, `DISABLE_SSL=true` so Thruster speaks plain HTTP behind the proxy, `/up` healthcheck, convenience aliases.
- `.kamal/secrets`: reference-only file (committed). Pulls values from env vars or a password manager — never holds raw credentials. Examples for 1Password / Bitwarden / AWS Secrets Manager included as comments.
- `.gitignore`: track only `.kamal/secrets`; ignore the rest of `.kamal/` (locks, bundles, host caches).
- `.dockerignore`: keep `.kamal/` out of the image.
- `KAMAL.md`: prerequisites, secret generation, first-time setup, daily commands, and an opt-out section for users who'd rather use Thruster's built-in Let's Encrypt instead of kamal-proxy.

## Notes
- Matches the upstream Docker deployment model: one self-contained container (SQLite + Redis + Resque + Puma + Thruster) with persistent state under `/rails/storage`. kamal-proxy is layered on top to provide zero-downtime rollouts and automatic SSL.
- The image name `leegeng/once-campfire` combined with `registry.server: ghcr.io` resolves to `ghcr.io/leegeng/once-campfire`. Change both if you fork to another namespace.
- `Gemfile.lock` is intentionally not updated in this PR — local Ruby is 3.4.5-only, and bundling here would touch unrelated gem versions. Reviewer can run `bundle install` once and amend.

## Test plan
- [ ] `bundle install` succeeds after pulling the branch
- [ ] `bundle exec kamal config` parses `config/deploy.yml` (after replacing the two placeholders)
- [ ] Visit the deployed domain and complete the first-run admin setup
- [ ] `bundle exec kamal app logs -f` streams live logs
- [ ] `bundle exec kamal rollback` works (deploy twice, roll back, app stays up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)