### PR TITLE
feat: Add user poll messages

### DIFF
--- a/app/assets/images/chart.svg
+++ b/app/assets/images/chart.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 16V9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M10 16V4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M16 16V12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M3 16H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -1,5 +1,8 @@
 .flash {
+  align-items: center;
+  animation: appear-then-fade 3s 300ms both;
   display: flex;
+  gap: 0.5rem;
   inset-block-start: var(--block-space);
   inset-inline-start: 50%;
   justify-content: center;
@@ -9,7 +12,6 @@
 }
 
 .flash__inner {
-  animation: appear-then-fade 3s 300ms both;
   aspect-ratio: 1;
   background-color: var(--flash-background, var(--color-positive));
   border-radius: 50%;
@@ -20,4 +22,17 @@
   img {
     grid-area: 1/1;
   }
+}
+
+.flash--alert .flash__inner {
+  --flash-background: var(--color-negative);
+}
+
+.flash__message {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 999px;
+  color: var(--color-text);
+  font-weight: 600;
+  padding: 0.6em 0.9em;
 }

--- a/app/assets/stylesheets/polls.css
+++ b/app/assets/stylesheets/polls.css
@@ -1,0 +1,155 @@
+.poll {
+  --poll-accent: var(--color-link);
+  --poll-accent-soft: var(--color-selected);
+  --poll-track: var(--color-border-dark);
+  --poll-muted: color-mix(in oklch, var(--color-text), transparent 35%);
+
+  display: grid;
+  gap: 0.8rem;
+  inline-size: min(36rem, 70vw);
+  margin-block-start: 0.35rem;
+
+  @media (max-width: 100ch) {
+    inline-size: 100%;
+  }
+}
+
+.poll__question {
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.poll__results {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.poll__option-result {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.poll__option-heading {
+  align-items: baseline;
+  column-gap: 0.6ch;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.poll__option-label {
+  font-weight: 700;
+}
+
+.poll__option-meta,
+.poll__footer {
+  color: var(--poll-muted);
+  font-size: 0.9em;
+}
+
+.poll__bar-row {
+  align-items: center;
+  display: grid;
+  gap: 0.75ch;
+  grid-template-columns: minmax(8ch, 1fr) auto;
+}
+
+.poll__bar-track {
+  background: var(--poll-track);
+  border-radius: 2em;
+  block-size: 0.7em;
+  overflow: hidden;
+}
+
+.poll__bar-fill {
+  --poll-percent: 0%;
+
+  background: var(--poll-accent);
+  block-size: 100%;
+  border-radius: inherit;
+  inline-size: var(--poll-percent, 0%);
+  min-inline-size: 0.35em;
+  transition: inline-size 180ms ease;
+}
+
+.poll__bar-fill[style*="--poll-percent: 0%"] {
+  min-inline-size: 0;
+}
+
+.poll__voters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.poll__voter-chip {
+  background: var(--poll-accent-soft);
+  border-radius: 0.35em;
+  color: var(--color-link);
+  font-size: 0.85em;
+  padding: 0.1em 0.35em;
+}
+
+.poll__ballot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.poll__ballot form {
+  display: contents;
+}
+
+.poll__choice {
+  --btn-border-color: var(--color-border-darker);
+  --btn-background: transparent;
+}
+
+.poll__choice--selected {
+  --btn-background: var(--color-text);
+  --btn-color: var(--color-text-reversed);
+}
+
+.poll__choice:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.poll-form__option-row {
+  inline-size: 100%;
+}
+
+.poll-form__option-input {
+  flex: 1;
+  min-inline-size: 0;
+}
+
+.poll-form__remove-option {
+  flex-shrink: 0;
+  min-inline-size: 8ch;
+  white-space: nowrap;
+}
+
+.poll-create {
+  align-items: start;
+  display: grid;
+  inline-size: min(42rem, 100%);
+  margin-inline: auto;
+  place-self: center;
+}
+
+.poll-create__back {
+  --btn-border-radius: 0.5em;
+}
+
+.poll-editor-message {
+  --message-background: var(--color-bg);
+  --message-color: var(--color-text);
+  --content-padding-block: var(--block-space);
+  --content-padding-inline: var(--inline-space);
+
+  inline-size: min(42rem, 100%);
+}
+
+.poll-form {
+  margin-block-start: 1rem;
+}

--- a/app/controllers/concerns/poll_parameters.rb
+++ b/app/controllers/concerns/poll_parameters.rb
@@ -1,0 +1,8 @@
+module PollParameters
+  extend ActiveSupport::Concern
+
+  private
+    def poll_params
+      params.require(:poll).permit(:question, :multi_select, options_attributes: [ :id, :body, :position, :_destroy ])
+    end
+end

--- a/app/controllers/messages/poll_votes_controller.rb
+++ b/app/controllers/messages/poll_votes_controller.rb
@@ -1,0 +1,73 @@
+class Messages::PollVotesController < ApplicationController
+  include ActionView::RecordIdentifier
+
+  before_action :set_poll
+
+  def create
+    if @poll.closed?
+      head :unprocessable_entity
+      return
+    end
+
+    option = @poll.options.find_by(id: params[:poll_option_id])
+    unless option
+      head :not_found
+      return
+    end
+
+    if @poll.multi_select?
+      @poll.votes.find_or_create_by!(poll_option: option, voter: Current.user)
+    else
+      @poll.votes.where(voter: Current.user).delete_all
+      @poll.votes.create!(poll_option: option, voter: Current.user)
+    end
+
+    broadcast_poll_update
+    render_poll_update
+  end
+
+  def destroy
+    if @poll.closed?
+      head :unprocessable_entity
+      return
+    end
+
+    option = @poll.options.find_by(id: params[:id])
+    unless option
+      head :not_found
+      return
+    end
+
+    @poll.votes.where(voter: Current.user, poll_option: option).delete_all
+
+    broadcast_poll_update
+    render_poll_update
+  end
+
+  private
+    def set_poll
+      message = Current.user.reachable_messages.with_poll.find_by(id: params[:message_id])
+      @poll = message&.poll
+
+      head :not_found unless @poll
+    end
+
+    def broadcast_poll_update
+      reload_poll
+
+      # Results are shared, but the ballot includes the current voter's selected state.
+      @poll.message.broadcast_replace_to @poll.message.room, :messages,
+        target: [ @poll, :results ],
+        partial: "messages/polls/results",
+        locals: { poll: @poll },
+        attributes: { maintain_scroll: true }
+    end
+
+    def render_poll_update
+      render turbo_stream: turbo_stream.replace(dom_id(@poll, :ballot), partial: "messages/polls/ballot", locals: { poll: @poll, voter: Current.user })
+    end
+
+    def reload_poll
+      @poll = Poll.includes(:message, options: { votes: :voter }).find(@poll.id)
+    end
+end

--- a/app/controllers/messages/polls_controller.rb
+++ b/app/controllers/messages/polls_controller.rb
@@ -6,7 +6,6 @@ class Messages::PollsController < ApplicationController
 
   def edit
     @poll = @message.poll
-    head :unprocessable_entity unless @poll.open?
   end
 
   def update

--- a/app/controllers/messages/polls_controller.rb
+++ b/app/controllers/messages/polls_controller.rb
@@ -1,0 +1,59 @@
+class Messages::PollsController < ApplicationController
+  include PollParameters
+
+  before_action :set_message
+  before_action :ensure_can_administer
+
+  def edit
+    @poll = @message.poll
+    head :unprocessable_entity unless @poll.open?
+  end
+
+  def update
+    @poll = @message.poll
+    return head :unprocessable_entity unless @poll.open?
+
+    @poll.update!(editable_poll_params)
+    broadcast_poll_update
+
+    if request.format.turbo_stream?
+      render turbo_stream: turbo_stream.replace(@message, partial: "messages/message", locals: { message: @message })
+    elsif turbo_frame_request?
+      render partial: "messages/message", locals: { message: @message }
+    else
+      redirect_to room_message_url(@message.room, @message)
+    end
+  end
+
+  def close
+    @message.poll.close!
+    broadcast_poll_update
+
+    head :ok
+  end
+
+  private
+    def set_message
+      @message = Message.find(params[:message_id])
+    end
+
+    def ensure_can_administer
+      unless Current.user.can_administer?(@message)
+        message = "Only the poll creator or an admin can edit or close this poll."
+
+        if request.format.turbo_stream? || turbo_frame_request?
+          render turbo_stream: turbo_stream.update("flash", partial: "layouts/flash", locals: { alert: true, message: message }), status: :forbidden
+        else
+          redirect_back fallback_location: room_path(@message.room), alert: message
+        end
+      end
+    end
+
+    def editable_poll_params
+      @poll.structure_editable? ? poll_params : poll_params.slice(:question)
+    end
+
+    def broadcast_poll_update
+      @message.broadcast_replace_to @message.room, :messages, target: @message, partial: "messages/message", locals: { message: @message }, attributes: { maintain_scroll: true }
+    end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -31,6 +31,7 @@ class MessagesController < ApplicationController
   end
 
   def edit
+    head :unprocessable_entity if @message.content_type.poll?
   end
 
   def update
@@ -56,13 +57,14 @@ class MessagesController < ApplicationController
 
 
     def find_paged_messages
+      relation = @room.messages.with_creator.with_poll
       case
       when params[:before].present?
-        @room.messages.with_creator.page_before(@room.messages.find(params[:before]))
+        relation.page_before(@room.messages.find(params[:before]))
       when params[:after].present?
-        @room.messages.with_creator.page_after(@room.messages.find(params[:after]))
+        relation.page_after(@room.messages.find(params[:after]))
       else
-        @room.messages.with_creator.last_page
+        relation.last_page
       end
     end
 

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,0 +1,61 @@
+class PollsController < ApplicationController
+  include PollParameters
+  include RoomScoped
+
+  def new
+    @poll = Poll.new
+    @client_message_id = pending_client_message_id
+    Poll::MIN_OPTIONS.times.with_index { |_, i| @poll.options.build(position: i) }
+  end
+
+  def create
+    @client_message_id = submitted_client_message_id || pending_client_message_id
+    existing_message = @room.messages.find_by(client_message_id: @client_message_id)
+
+    if existing_message
+      clear_pending_client_message_id
+      redirect_to room_path(@room)
+    else
+      message = @room.messages.create_with_attachment!(message_params.merge(creator: Current.user)) do |new_message|
+        @poll = new_message.build_poll(poll_params)
+      end
+
+      message.broadcast_create
+      clear_pending_client_message_id
+      redirect_to room_path(@room)
+    end
+  rescue ActiveRecord::RecordInvalid => error
+    @poll = error.record.is_a?(Poll) ? error.record : error.record.poll
+    ensure_minimum_options
+
+    render :new, status: :unprocessable_entity
+  end
+
+  private
+    def message_params
+      params.fetch(:message, ActionController::Parameters.new).permit(:client_message_id).reverse_merge(client_message_id: @client_message_id)
+    end
+
+    def pending_client_message_id
+      session[pending_client_message_id_key] ||= Random.uuid
+    end
+
+    def submitted_client_message_id
+      params.dig(:message, :client_message_id).presence
+    end
+
+    def clear_pending_client_message_id
+      session.delete(pending_client_message_id_key)
+    end
+
+    def pending_client_message_id_key
+      "room_#{@room.id}_poll_client_message_id"
+    end
+
+    def ensure_minimum_options
+      start_position = @poll.options.size
+      (Poll::MIN_OPTIONS - start_position).times do |i|
+        @poll.options.build(position: start_position + i)
+      end
+    end
+end

--- a/app/controllers/users/sidebars_controller.rb
+++ b/app/controllers/users/sidebars_controller.rb
@@ -16,7 +16,7 @@ class Users::SidebarsController < ApplicationController
 
     def find_direct_placeholder_users
       exclude_user_ids = user_ids_already_in_direct_rooms_with_current_user.including(Current.user.id)
-      User.active.where.not(id: exclude_user_ids).order(:created_at).limit([DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0].max)
+      User.active.where.not(id: exclude_user_ids).order(:created_at).limit([ DIRECT_PLACEHOLDERS - exclude_user_ids.count, 0 ].max)
     end
 
     def user_ids_already_in_direct_rooms_with_current_user

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -56,6 +56,8 @@ module MessagesHelper
       message_attachment_presentation(message)
     when "sound"
       message_sound_presentation(message)
+    when "poll"
+      render "messages/polls/poll", message: message, poll: message.poll
     else
       auto_link h(ContentFilters::TextMessagePresentationFilters.apply(message.body.body)), html: { target: "_blank" }
     end

--- a/app/javascript/controllers/poll_actions_controller.js
+++ b/app/javascript/controllers/poll_actions_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "adminAction" ]
+  static values = { creatorId: Number }
+
+  connect() {
+    if (this.#canAdministerPoll) {
+      this.adminActionTargets.forEach((target) => target.hidden = false)
+    }
+  }
+
+  get #canAdministerPoll() {
+    return document.body.classList.contains("admin") || window.Current?.user?.id === this.creatorIdValue
+  }
+}

--- a/app/javascript/controllers/poll_form_controller.js
+++ b/app/javascript/controllers/poll_form_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "error", "question" ]
+  static values = { maxQuestionLength: Number }
+
+  validate(event) {
+    const question = this.questionTarget.editor.getDocument().toString().trim()
+
+    if (question.length > this.maxQuestionLengthValue) {
+      event.preventDefault()
+      this.errorTarget.textContent = `Question is too long (max ${this.maxQuestionLengthValue} characters).`
+      this.errorTarget.hidden = false
+    } else {
+      this.errorTarget.hidden = true
+    }
+  }
+}

--- a/app/javascript/controllers/poll_options_controller.js
+++ b/app/javascript/controllers/poll_options_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "list", "template", "row", "addButton" ]
+  static values = { min: Number, max: Number }
+
+  #nextIndex = 0
+
+  connect() {
+    this.#nextIndex = this.rowTargets.length
+    this.#refresh()
+  }
+
+  add(event) {
+    event.preventDefault()
+    if (this.#visibleRows().length >= this.maxValue) return
+
+    const index = this.#nextIndex++
+    const html = this.templateTarget.innerHTML.replaceAll("__INDEX__", index)
+    this.listTarget.insertAdjacentHTML("beforeend", html)
+    this.normalizePositions()
+    this.#refresh()
+  }
+
+  remove(event) {
+    event.preventDefault()
+    if (this.#visibleRows().length <= this.minValue) return
+
+    const row = event.currentTarget.closest("[data-poll-options-target='row']")
+    const destroyInput = row?.querySelector("[data-poll-options-destroy]")
+    if (destroyInput) {
+      destroyInput.value = "1"
+      row.hidden = true
+    } else {
+      row?.remove()
+    }
+    this.normalizePositions()
+    this.#refresh()
+  }
+
+  normalizePositions() {
+    this.#visibleRows().forEach((row, index) => {
+      const positionInput = row.querySelector("[data-poll-options-position]")
+      if (positionInput) positionInput.value = index
+    })
+  }
+
+  #refresh() {
+    const visibleRows = this.#visibleRows()
+    const atMin = visibleRows.length <= this.minValue
+
+    this.addButtonTarget.disabled = visibleRows.length >= this.maxValue
+    visibleRows.forEach((row) => {
+      const removeButton = row.querySelector("[data-poll-options-remove]")
+      if (removeButton) removeButton.disabled = atMin
+    })
+  }
+
+  #visibleRows() {
+    return this.rowTargets.filter((row) => !row.hidden)
+  }
+}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,6 +5,8 @@ class Message < ApplicationRecord
   belongs_to :creator, class_name: "User", default: -> { Current.user }
 
   has_many :boosts, dependent: :destroy
+  has_one :poll, dependent: :destroy
+  validates_associated :poll
 
   has_rich_text :body
 
@@ -19,8 +21,10 @@ class Message < ApplicationRecord
       .includes(attachment_blob: :variant_records)
   }
   scope :with_boosts, -> { includes(boosts: :booster) }
+  scope :with_poll, -> { includes(poll: { options: { votes: :voter } }) }
 
   def plain_text_body
+    return poll.question_plain_text if poll.present?
     body.to_plain_text.presence || attachment&.filename&.to_s || ""
   end
 
@@ -31,6 +35,7 @@ class Message < ApplicationRecord
   def content_type
     case
     when attachment?    then "attachment"
+    when poll.present?  then "poll"
     when sound.present? then "sound"
     else                     "text"
     end.inquiry

--- a/app/models/message/attachment.rb
+++ b/app/models/message/attachment.rb
@@ -12,7 +12,7 @@ module Message::Attachment
 
   module ClassMethods
     def create_with_attachment!(attributes)
-      create!(attributes).tap(&:process_attachment)
+      create!(attributes) { |message| yield message if block_given? }.tap(&:process_attachment)
     end
   end
 

--- a/app/models/message/mentionee.rb
+++ b/app/models/message/mentionee.rb
@@ -7,10 +7,9 @@ module Message::Mentionee
 
   private
     def mentioned_users
-      if body.body
-        body.body.attachables.grep(User).uniq
-      else
-        []
-      end
+      attachments = []
+      attachments.concat(body.body.attachables) if body.body
+      attachments.concat(poll.question.body.attachables) if poll&.question&.body
+      attachments.grep(User).uniq
     end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,0 +1,55 @@
+class Poll < ApplicationRecord
+  QUESTION_MAX_LENGTH = 280
+  OPTION_MAX_LENGTH = 120
+  MIN_OPTIONS = 2
+  MAX_OPTIONS = 10
+
+  belongs_to :message, touch: true
+  has_many :options, -> { order(:position) }, class_name: "PollOption", dependent: :destroy, inverse_of: :poll
+  has_many :votes, class_name: "PollVote", dependent: :destroy, inverse_of: :poll
+
+  has_rich_text :question
+
+  accepts_nested_attributes_for :options, allow_destroy: true
+
+  validates :message_id, uniqueness: true
+  validates :multi_select, inclusion: { in: [ true, false ] }
+  validate :question_presence_and_length
+  validate :option_count
+
+  def closed?
+    closed_at.present?
+  end
+
+  def structure_editable?
+    open? && votes.none?
+  end
+
+  def close!
+    update!(closed_at: Time.current)
+  end
+
+  def open?
+    !closed?
+  end
+
+  def question_plain_text
+    question.to_plain_text.squish
+  end
+
+  private
+    def question_presence_and_length
+      plain = question_plain_text
+      errors.add(:question, :blank) if plain.blank?
+      if plain.length > QUESTION_MAX_LENGTH
+        errors.add(:question, "is too long (maximum is #{QUESTION_MAX_LENGTH} characters)")
+      end
+    end
+
+    def option_count
+      kept_options = options.reject(&:marked_for_destruction?)
+      if kept_options.size < MIN_OPTIONS || kept_options.size > MAX_OPTIONS
+        errors.add(:options, "must have between #{MIN_OPTIONS} and #{MAX_OPTIONS} options")
+      end
+    end
+end

--- a/app/models/poll_option.rb
+++ b/app/models/poll_option.rb
@@ -1,0 +1,7 @@
+class PollOption < ApplicationRecord
+  belongs_to :poll
+  has_many :votes, class_name: "PollVote", dependent: :destroy, inverse_of: :poll_option
+
+  validates :body, presence: true, length: { maximum: Poll::OPTION_MAX_LENGTH }
+  validates :position, presence: true
+end

--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -1,0 +1,16 @@
+class PollVote < ApplicationRecord
+  belongs_to :poll
+  belongs_to :poll_option
+  belongs_to :voter, class_name: "User"
+
+  after_commit -> { poll.message.touch }
+
+  validates :poll_option_id, uniqueness: { scope: :voter_id }
+  validate :option_belongs_to_poll
+
+  private
+    def option_belongs_to_poll
+      return if poll_option.blank? || poll.blank?
+      errors.add(:poll_option, "must belong to poll") if poll_option.poll_id != poll_id
+    end
+end

--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -3,12 +3,22 @@ class PollVote < ApplicationRecord
   belongs_to :poll_option
   belongs_to :voter, class_name: "User"
 
-  after_commit -> { poll.message.touch }
+  after_create_commit :touch_message
+  after_update_commit :touch_message
+  after_destroy_commit :touch_message_if_poll_exists
 
   validates :poll_option_id, uniqueness: { scope: :voter_id }
   validate :option_belongs_to_poll
 
   private
+    def touch_message
+      poll.message.touch
+    end
+
+    def touch_message_if_poll_exists
+      Poll.find_by(id: poll_id)&.message&.touch
+    end
+
     def option_belongs_to_poll
       return if poll_option.blank? || poll.blank?
       errors.add(:poll_option, "must belong to poll") if poll_option.poll_id != poll_id

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,19 @@
+<% alert = local_assigns.fetch(:alert, flash[:alert]) %>
+<% message = local_assigns.fetch(:message, alert || flash[:notice]) %>
+
+<% if message %>
+  <div class="flash <%= "flash--alert" if alert %>" role="alert" aria-atomic="true" data-controller="element-removal" data-action="animationend->element-removal#remove">
+    <div class="flash__inner shadow">
+      <% if alert %>
+        <%= image_tag "alert.svg", aria: { hidden: true }, size: 24, class: "colorize--white" %>
+      <% else %>
+        <%= image_tag "check.svg", aria: { hidden: true }, size: 24, class: "colorize--white" %>
+      <% end %>
+    </div>
+    <% if alert %>
+      <span class="flash__message shadow"><%= message %></span>
+    <% else %>
+      <span class="for-screen-reader"><%= message %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,18 +36,9 @@
       <%= yield :nav %>
     </nav>
 
-    <% if notice = flash[:notice] || flash[:alert] %>
-      <div class="flash" data-controller="element-removal" data-action="animationend->element-removal#remove">
-        <div class="flash__inner shadow" style="<%= "--flash-background: var(--color-negative)" if flash[:alert] %>">
-          <% if flash[:alert] %>
-            <%= image_tag "alert.svg", aria: { hidden: true }, size: 24, class: "colorize--white" %></span>
-          <% else %>
-            <%= image_tag "check.svg", aria: { hidden: true }, size: 24, class: "colorize--white" %></span>
-          <% end %>
-        </div>
-        <span class="for-screen-reader" role="alert" aria-atomic="true"><%= notice %></span>
-      </div>
-    <% end %>
+    <div id="flash">
+      <%= render "layouts/flash" %>
+    </div>
 
     <main id="main-content">
       <%= yield %>

--- a/app/views/messages/_actions.html.erb
+++ b/app/views/messages/_actions.html.erb
@@ -1,6 +1,9 @@
 <%# Be sure to check/update messages/_template.html.erb when changing this file %>
 
-<div class="message__actions" data-controller="soft-keyboard">
+<% poll_message = message.content_type.poll? %>
+<div class="message__actions"
+    data-controller="soft-keyboard<%= " poll-actions" if poll_message %>"
+    <% if poll_message %>data-poll-actions-creator-id-value="<%= message.creator_id %>"<% end %>>
   <%= tag.details class: "position-relative",
       data: { controller: "popup", action: "keydown.esc->popup#close toggle->popup#toggle click@document->popup#closeOnClickOutside", popup_orientation_top_class: "popup-orientation-top" } do %>
     <summary class="btn message__action-btn message__options-btn">
@@ -48,9 +51,22 @@
           <%= image_tag "link.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
         <% end %>
 
-        <%= link_to edit_room_message_path(message.room, message), class: "btn message__action-btn center full-width message__edit-btn",
-              data: { turbo_frame: dom_id(message, :edit) }, title: "Edit", aria: { label: "Edit"} do %>
-          <%= image_tag "pencil.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
+        <% if message.poll&.open? %>
+          <%= link_to edit_message_poll_path(message), class: "btn message__action-btn center full-width message__edit-btn",
+                data: { turbo_frame: dom_id(message, :edit), poll_actions_target: "adminAction" }, hidden: true, title: "Edit poll", aria: { label: "Edit poll" } do %>
+            <%= image_tag "pencil.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
+          <% end %>
+        <% end %>
+
+        <% if message.poll&.open? %>
+          <%= button_to "Close poll", close_message_poll_path(message), method: :patch, class: "btn message__action-btn center full-width", form: { hidden: true, data: { turbo: true, poll_actions_target: "adminAction" } } %>
+        <% end %>
+
+        <% unless message.content_type.poll? %>
+          <%= link_to edit_room_message_path(message.room, message), class: "btn message__action-btn center full-width message__edit-btn",
+                data: { turbo_frame: dom_id(message, :edit) }, title: "Edit", aria: { label: "Edit"} do %>
+            <%= image_tag "pencil.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/messages/_actions.html.erb
+++ b/app/views/messages/_actions.html.erb
@@ -51,9 +51,9 @@
           <%= image_tag "link.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
         <% end %>
 
-        <% if message.poll&.open? %>
+        <% if message.content_type.poll? %>
           <%= link_to edit_message_poll_path(message), class: "btn message__action-btn center full-width message__edit-btn",
-                data: { turbo_frame: dom_id(message, :edit), poll_actions_target: "adminAction" }, hidden: true, title: "Edit poll", aria: { label: "Edit poll" } do %>
+                data: { turbo_frame: dom_id(message, :edit), poll_actions_target: "adminAction" }, hidden: true, title: "Manage poll", aria: { label: "Manage poll" } do %>
             <%= image_tag "pencil.svg", class: "colorize--black", size: 20, aria: { hidden: "true" } %>
           <% end %>
         <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,6 @@
 <%# Be sure to check/update messages/_template.html.erb when changing this file %>
 
-<% cache message do %>
+<% cache [ message, message.poll ] do %>
   <%= message_tag message do %>
     <h2 class="message__day-separator"><%= local_datetime_tag message.created_at, style: :date %></h2>
 

--- a/app/views/messages/polls/_ballot.html.erb
+++ b/app/views/messages/polls/_ballot.html.erb
@@ -1,0 +1,21 @@
+<div id="<%= dom_id(poll, :ballot) %>" class="poll__ballot">
+  <% selected_ids = poll.options.flat_map(&:votes).select { |vote| vote.voter_id == voter.id }.map(&:poll_option_id) %>
+  <% poll.options.each do |option| %>
+    <% selected = selected_ids.include?(option.id) %>
+    <% if poll.closed? %>
+      <button class="btn poll__choice <%= "poll__choice--selected" if selected %>" type="button" disabled><%= selected ? "Voted: #{option.body}" : option.body %></button>
+    <% elsif selected %>
+      <%= button_to option.body,
+            message_poll_vote_path(poll.message, option),
+            method: :delete,
+            class: "btn poll__choice poll__choice--selected",
+            form: { data: { turbo: true } } %>
+    <% else %>
+      <%= button_to option.body,
+            message_poll_votes_path(poll.message),
+            params: { poll_option_id: option.id },
+            class: "btn poll__choice",
+            form: { data: { turbo: true } } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/messages/polls/_delete_button.html.erb
+++ b/app/views/messages/polls/_delete_button.html.erb
@@ -1,0 +1,5 @@
+<%= button_tag class: "btn btn--negative", type: "submit", form: dom_id(message, :delete_form),
+      data: { turbo_confirm: "Are you sure you want to delete this poll?" } do %>
+  <%= image_tag "trash.svg", aria: { hidden: "true" } %>
+  <span class="for-screen-reader">Delete poll</span>
+<% end %>

--- a/app/views/messages/polls/_poll.html.erb
+++ b/app/views/messages/polls/_poll.html.erb
@@ -1,0 +1,7 @@
+<div class="poll">
+  <div class="poll__question">
+    <%= auto_link h(ContentFilters::TextMessagePresentationFilters.apply(poll.question.body)), html: { target: "_blank" } %>
+  </div>
+  <%= render "messages/polls/results", poll: poll, voter: Current.user %>
+  <%= render "messages/polls/ballot", poll: poll, voter: Current.user %>
+</div>

--- a/app/views/messages/polls/_results.html.erb
+++ b/app/views/messages/polls/_results.html.erb
@@ -1,0 +1,29 @@
+<div id="<%= dom_id(poll, :results) %>" class="poll__results">
+  <% total = poll.options.sum { |option| option.votes.size } %>
+  <% poll.options.each do |option| %>
+    <% count = option.votes.size %>
+    <% percent = total.zero? ? 0 : ((count.to_f / total) * 100).round %>
+    <div class="poll__option-result">
+      <div class="poll__option-heading">
+        <span class="poll__option-label"><%= option.body %></span>
+        <span class="poll__option-meta"><%= count %> vote<%= "s" unless count == 1 %></span>
+      </div>
+
+      <div class="poll__bar-row">
+        <div class="poll__bar-track" aria-hidden="true">
+          <div class="poll__bar-fill" style="--poll-percent: <%= percent %>%"></div>
+        </div>
+        <span class="poll__option-meta"><%= percent %>%</span>
+      </div>
+
+      <% if option.votes.any? %>
+        <div class="poll__voters" aria-label="Voters for <%= option.body %>">
+          <% option.votes.each do |vote| %>
+            <span class="poll__voter-chip">@<%= vote.voter.name %></span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <span class="poll__footer"><%= total %> total vote<%= "s" unless total == 1 %><%= " - closed" if poll.closed? %></span>
+</div>

--- a/app/views/messages/polls/edit.html.erb
+++ b/app/views/messages/polls/edit.html.erb
@@ -1,0 +1,22 @@
+<turbo-frame id="<%= dom_id(@message, :edit) %>">
+  <div class="message__body position-relative" data-controller="scroll-into-view">
+    <div class="message__body-content message__body-content--editing poll-editor-message gap border">
+      <%= render "polls/editor",
+            title: "Edit poll",
+            poll: @poll,
+            room: @message.room,
+            url: message_poll_path(@message),
+            method: :patch,
+            submit_label: "Save poll",
+            cancel_link: link_to("Cancel", room_message_path(@message.room, @message), class: "btn", data: { turbo_frame: dom_id(@message, :edit) }),
+            inline: true %>
+    </div>
+
+    <div class="message__actions flex flex-wrap">
+      <%= link_to room_message_path(@message.room, @message), class: "message__action-btn message__edit-close-btn txt-small btn btn--borderless" do %>
+        <%= image_tag "remove.svg", class: "colorize--black", aria: { hidden: "true" } %>
+        <span class="for-screen-reader">Close editor and discard changes</span>
+      <% end %>
+    </div>
+  </div>
+</turbo-frame>

--- a/app/views/messages/polls/edit.html.erb
+++ b/app/views/messages/polls/edit.html.erb
@@ -1,15 +1,26 @@
 <turbo-frame id="<%= dom_id(@message, :edit) %>">
   <div class="message__body position-relative" data-controller="scroll-into-view">
     <div class="message__body-content message__body-content--editing poll-editor-message gap border">
-      <%= render "polls/editor",
-            title: "Edit poll",
-            poll: @poll,
-            room: @message.room,
-            url: message_poll_path(@message),
-            method: :patch,
-            submit_label: "Save poll",
-            cancel_link: link_to("Cancel", room_message_path(@message.room, @message), class: "btn", data: { turbo_frame: dom_id(@message, :edit) }),
-            inline: true %>
+      <% if @poll.open? %>
+        <%= render "polls/editor",
+              title: "Edit poll",
+              poll: @poll,
+              room: @message.room,
+              url: message_poll_path(@message),
+              method: :patch,
+              submit_label: "Save poll",
+              delete_button: render("messages/polls/delete_button", message: @message),
+              inline: true %>
+      <% else %>
+        <div class="poll-editor">
+          <h2 class="margin-none">Manage poll</h2>
+          <p class="txt-small colorize--grey margin-none">This poll is closed, so it can no longer be edited.</p>
+          <div class="message__edit-btns flex align-center justify-space-between gap full-width pad-block-start-half">
+            <span></span>
+            <%= render "messages/polls/delete_button", message: @message %>
+          </div>
+        </div>
+      <% end %>
     </div>
 
     <div class="message__actions flex flex-wrap">
@@ -18,5 +29,7 @@
         <span class="for-screen-reader">Close editor and discard changes</span>
       <% end %>
     </div>
+
+    <%= form_with url: room_message_path(@message.room, @message), method: :delete, id: dom_id(@message, :delete_form), data: { turbo_frame: dom_id(@message, :edit) } %>
   </div>
 </turbo-frame>

--- a/app/views/polls/_editor.html.erb
+++ b/app/views/polls/_editor.html.erb
@@ -10,6 +10,7 @@
         url: url,
         method: method,
         submit_label: submit_label,
+        delete_button: local_assigns[:delete_button],
         client_message_id: local_assigns[:client_message_id],
-        cancel_link: cancel_link %>
+        cancel_link: local_assigns[:cancel_link] %>
 </div>

--- a/app/views/polls/_editor.html.erb
+++ b/app/views/polls/_editor.html.erb
@@ -1,0 +1,15 @@
+<% inline = local_assigns.fetch(:inline, false) %>
+<% framed = local_assigns.fetch(:framed, !inline) %>
+
+<div class="poll-editor <%= "pad border-radius border shadow" if framed %>">
+  <h2 class="margin-none"><%= title %></h2>
+
+  <%= render "polls/form",
+        poll: poll,
+        room: room,
+        url: url,
+        method: method,
+        submit_label: submit_label,
+        client_message_id: local_assigns[:client_message_id],
+        cancel_link: cancel_link %>
+</div>

--- a/app/views/polls/_form.html.erb
+++ b/app/views/polls/_form.html.erb
@@ -1,0 +1,74 @@
+<%= form_with model: poll, url: url, method: method, class: "poll-form flex flex-column gap", data: {
+      controller: "poll-form poll-options",
+      action: "submit->poll-form#validate submit->poll-options#normalizePositions",
+      poll_form_max_question_length_value: Poll::QUESTION_MAX_LENGTH,
+      poll_options_min_value: Poll::MIN_OPTIONS,
+      poll_options_max_value: Poll::MAX_OPTIONS
+    } do |form| %>
+  <%= fields_for :message do |message_fields| %>
+    <%= message_fields.hidden_field :client_message_id, value: client_message_id unless poll.persisted? %>
+  <% end %>
+
+  <% structure_editable = poll.structure_editable? %>
+  <% unless structure_editable %>
+    <p class="txt-small colorize--grey margin-none">Voting has started, so only the question can be edited.</p>
+  <% end %>
+
+  <div class="composer--edit composer--rich-text">
+    <label class="txt-small">Question</label>
+    <%= form.rich_text_area :question,
+          aria: { label: "Poll question" },
+          data: {
+            poll_form_target: "question",
+            controller: "rich-autocomplete",
+            action: rich_text_data_actions,
+            rich_autocomplete_url_value: autocompletable_users_path(room_id: room.id),
+            permitted_attachment_types: "application/vnd.actiontext.opengraph-embed" } %>
+    <p class="txt-small colorize--grey margin-none">Max <%= Poll::QUESTION_MAX_LENGTH %> characters.</p>
+    <p class="txt-small txt-negative margin-none" data-poll-form-target="error" role="alert" hidden></p>
+  </div>
+
+  <div data-poll-options-target="list" class="flex flex-column gap">
+    <% poll.options.each_with_index do |option, index| %>
+      <%= form.fields_for :options, option, child_index: index do |option_fields| %>
+        <div data-poll-options-target="row" class="flex align-center gap poll-form__option-row">
+          <%= option_fields.hidden_field :id if option.persisted? %>
+          <%= option_fields.hidden_field :_destroy, value: "0", data: { poll_options_destroy: true } if option.persisted? %>
+          <%= option_fields.hidden_field :position, value: index, data: { poll_options_position: true } %>
+          <%= option_fields.text_field :body, required: true, maxlength: Poll::OPTION_MAX_LENGTH, class: "input poll-form__option-input", placeholder: "Option #{index + 1}", disabled: !structure_editable %>
+          <% if structure_editable %>
+            <button type="button" class="btn poll-form__remove-option" data-poll-options-remove="true" data-action="poll-options#remove">Remove</button>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <template data-poll-options-target="template">
+    <div data-poll-options-target="row" class="flex align-center gap poll-form__option-row">
+      <input type="hidden" name="poll[options_attributes][__INDEX__][position]" value="0" data-poll-options-position="true">
+      <input type="text" name="poll[options_attributes][__INDEX__][body]" required maxlength="<%= Poll::OPTION_MAX_LENGTH %>" class="input poll-form__option-input" placeholder="Option">
+      <button type="button" class="btn poll-form__remove-option" data-poll-options-remove="true" data-action="poll-options#remove">Remove</button>
+    </div>
+  </template>
+
+  <% if structure_editable %>
+    <button type="button" class="btn" data-poll-options-target="addButton" data-action="poll-options#add">Add option</button>
+  <% else %>
+    <span data-poll-options-target="addButton" hidden></span>
+  <% end %>
+
+  <label class="flex align-center gap" for="poll_multi_select">
+    <span class="switch">
+      <%= form.hidden_field :multi_select, value: "0" %>
+      <%= form.check_box :multi_select, { class: "switch__input", include_hidden: false, disabled: !structure_editable }, "1", "0" %>
+      <span class="switch__btn round"></span>
+    </span>
+    <span>Allow multiple choices</span>
+  </label>
+
+  <div class="flex gap">
+    <%= form.submit submit_label, class: "btn btn--reversed" %>
+    <%= cancel_link %>
+  </div>
+<% end %>

--- a/app/views/polls/_form.html.erb
+++ b/app/views/polls/_form.html.erb
@@ -60,8 +60,7 @@
 
   <label class="flex align-center gap" for="poll_multi_select">
     <span class="switch">
-      <%= form.hidden_field :multi_select, value: "0" %>
-      <%= form.check_box :multi_select, { class: "switch__input", include_hidden: false, disabled: !structure_editable }, "1", "0" %>
+      <%= form.check_box :multi_select, { class: "switch__input", disabled: !structure_editable }, "1", "0" %>
       <span class="switch__btn round"></span>
     </span>
     <span>Allow multiple choices</span>

--- a/app/views/polls/_form.html.erb
+++ b/app/views/polls/_form.html.erb
@@ -66,8 +66,11 @@
     <span>Allow multiple choices</span>
   </label>
 
-  <div class="flex gap">
-    <%= form.submit submit_label, class: "btn btn--reversed" %>
-    <%= cancel_link %>
+  <div class="message__edit-btns flex align-center justify-space-between gap full-width pad-block-start-half">
+    <span class="flex gap">
+      <%= form.submit submit_label, class: "btn btn--reversed" %>
+      <%= cancel_link %>
+    </span>
+    <%= delete_button %>
   </div>
 <% end %>

--- a/app/views/polls/new.html.erb
+++ b/app/views/polls/new.html.erb
@@ -1,0 +1,29 @@
+<% @page_title = "Create poll" %>
+<% @body_class = "sidebar" %>
+
+<%= render "rooms/show/nav", room: @room %>
+
+<% content_for :sidebar, sidebar_turbo_frame_tag(src: user_sidebar_path) %>
+
+<div id="message-area" class="message-area">
+  <div class="poll-create pad">
+    <%= render "polls/editor",
+          title: "Create poll",
+          poll: @poll,
+          room: @room,
+          url: room_polls_path(@room),
+          method: :post,
+          submit_label: "Create poll",
+          client_message_id: @client_message_id,
+          cancel_link: link_to("Cancel", room_path(@room), class: "btn") %>
+  </div>
+</div>
+
+<% content_for :footer do %>
+  <div class="composer flex align-end gap">
+    <%= link_to room_path(@room), class: "btn poll-create__back flex-item-no-shrink margin-block-end" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: "true" } %>
+      <span>Back to room</span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/rooms/show/_composer.html.erb
+++ b/app/views/rooms/show/_composer.html.erb
@@ -6,6 +6,11 @@
       <span class="for-screen-reader">Search</span>
     <% end %>
 
+    <%= link_to new_room_poll_path(room), class: "btn flex-item-no-shrink margin-block-end composer__context-btn" do %>
+      <%= image_tag "chart.svg", size: 20, aria: { hidden: "true" } %>
+      <span class="for-screen-reader">Create poll</span>
+    <% end %>
+
     <turbo-frame id="composer-frame">
       <%= composer_form_tag(room) do |form| %>
         <fieldset data-composer-target="fields" contents>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
 
   resources :rooms do
     resources :messages
+    resources :polls, only: %i[ new create ]
 
     post ":bot_key/messages", to: "messages/by_bots#create", as: :bot_messages
 
@@ -82,6 +83,10 @@ Rails.application.routes.draw do
   resources :messages do
     scope module: "messages" do
       resources :boosts
+      resource :poll, only: %i[ edit update ] do
+        patch :close
+        resources :votes, only: %i[ create destroy ], controller: "poll_votes"
+      end
     end
   end
 

--- a/db/migrate/20260528110000_create_polls.rb
+++ b/db/migrate/20260528110000_create_polls.rb
@@ -1,0 +1,30 @@
+class CreatePolls < ActiveRecord::Migration[8.0]
+  def change
+    create_table :polls do |t|
+      t.references :message, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
+      t.boolean :multi_select, null: false, default: false
+      t.datetime :closed_at
+
+      t.timestamps
+    end
+
+    create_table :poll_options do |t|
+      t.references :poll, null: false, foreign_key: { on_delete: :cascade }
+      t.string :body, null: false, limit: 120
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+    add_index :poll_options, [ :poll_id, :position ]
+
+    create_table :poll_votes do |t|
+      t.references :poll, null: false, foreign_key: { on_delete: :cascade }
+      t.references :poll_option, null: false, foreign_key: { on_delete: :cascade }
+      t.references :voter, null: false, foreign_key: { to_table: :users, on_delete: :cascade }
+
+      t.timestamps
+    end
+    add_index :poll_votes, [ :poll_option_id, :voter_id ], unique: true
+    add_index :poll_votes, [ :poll_id, :voter_id ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_28_110000) do
   create_table "accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "custom_styles"
@@ -104,6 +104,38 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
     t.index ["room_id"], name: "index_messages_on_room_id"
   end
 
+  create_table "poll_options", force: :cascade do |t|
+    t.string "body", limit: 120, null: false
+    t.datetime "created_at", null: false
+    t.integer "poll_id", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.index ["poll_id", "position"], name: "index_poll_options_on_poll_id_and_position"
+    t.index ["poll_id"], name: "index_poll_options_on_poll_id"
+  end
+
+  create_table "poll_votes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "poll_id", null: false
+    t.integer "poll_option_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "voter_id", null: false
+    t.index ["poll_id", "voter_id"], name: "index_poll_votes_on_poll_id_and_voter_id"
+    t.index ["poll_id"], name: "index_poll_votes_on_poll_id"
+    t.index ["poll_option_id", "voter_id"], name: "index_poll_votes_on_poll_option_id_and_voter_id", unique: true
+    t.index ["poll_option_id"], name: "index_poll_votes_on_poll_option_id"
+    t.index ["voter_id"], name: "index_poll_votes_on_voter_id"
+  end
+
+  create_table "polls", force: :cascade do |t|
+    t.datetime "closed_at"
+    t.datetime "created_at", null: false
+    t.integer "message_id", null: false
+    t.boolean "multi_select", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_polls_on_message_id", unique: true
+  end
+
   create_table "push_subscriptions", force: :cascade do |t|
     t.string "auth_key"
     t.datetime "created_at", null: false
@@ -172,6 +204,11 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_12_154340) do
   add_foreign_key "boosts", "messages"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users", column: "creator_id"
+  add_foreign_key "poll_options", "polls", on_delete: :cascade
+  add_foreign_key "poll_votes", "poll_options", on_delete: :cascade
+  add_foreign_key "poll_votes", "polls", on_delete: :cascade
+  add_foreign_key "poll_votes", "users", column: "voter_id", on_delete: :cascade
+  add_foreign_key "polls", "messages", on_delete: :cascade
   add_foreign_key "push_subscriptions", "users"
   add_foreign_key "searches", "users"
   add_foreign_key "sessions", "users"

--- a/test/controllers/messages/poll_votes_controller_test.rb
+++ b/test/controllers/messages/poll_votes_controller_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Messages::PollVotesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in :david
+    @poll = create_poll
+    @message = @poll.message
+  end
+
+  test "create vote" do
+    option = @poll.options.first
+
+    assert_difference -> { @poll.votes.count }, 1 do
+      post message_poll_votes_url(@message, format: :turbo_stream), params: { poll_option_id: option.id }
+      assert_response :success
+    end
+  end
+
+  test "single-select replaces prior vote" do
+    first_option, second_option = @poll.options.first(2)
+    post message_poll_votes_url(@message, format: :turbo_stream), params: { poll_option_id: first_option.id }
+
+    assert_no_difference -> { @poll.votes.count } do
+      post message_poll_votes_url(@message, format: :turbo_stream), params: { poll_option_id: second_option.id }
+    end
+
+    assert_equal [ second_option.id ], @poll.votes.where(voter: users(:david)).pluck(:poll_option_id)
+  end
+
+  test "destroy vote" do
+    option = @poll.options.first
+    @poll.votes.create!(poll_option: option, voter: users(:david))
+
+    assert_difference -> { @poll.votes.count }, -1 do
+      delete message_poll_vote_url(@message, option, format: :turbo_stream)
+      assert_response :success
+    end
+  end
+
+  test "closed polls cannot be voted" do
+    @poll.close!
+
+    assert_no_difference -> { @poll.votes.count } do
+      post message_poll_votes_url(@message, format: :turbo_stream), params: { poll_option_id: @poll.options.first.id }
+      assert_response :unprocessable_entity
+    end
+  end
+
+  test "create vote with stale option id returns not found" do
+    assert_no_difference -> { @poll.votes.count } do
+      post message_poll_votes_url(@message, format: :turbo_stream), params: { poll_option_id: 0 }
+      assert_response :not_found
+    end
+  end
+
+  test "destroy vote with stale option id returns not found" do
+    assert_no_difference -> { @poll.votes.count } do
+      delete message_poll_vote_url(@message, 0, format: :turbo_stream)
+      assert_response :not_found
+    end
+  end
+
+  test "create vote is not allowed outside rooms the user can reach" do
+    poll = create_poll(room: rooms(:watercooler))
+    sign_in :jz
+
+    assert_no_difference -> { poll.votes.count } do
+      post message_poll_votes_url(poll.message, format: :turbo_stream), params: { poll_option_id: poll.options.first.id }
+      assert_response :not_found
+    end
+  end
+
+  test "destroy vote is not allowed outside rooms the user can reach" do
+    poll = create_poll(room: rooms(:watercooler))
+    option = poll.options.first
+    poll.votes.create!(poll_option: option, voter: users(:david))
+    sign_in :jz
+
+    assert_no_difference -> { poll.votes.count } do
+      delete message_poll_vote_url(poll.message, option, format: :turbo_stream)
+      assert_response :not_found
+    end
+  end
+
+  private
+    def create_poll(room: rooms(:designers))
+      message = room.messages.create!(creator: users(:jason), body: "", client_message_id: SecureRandom.uuid)
+      message.create_poll!(question: "Choose", options_attributes: [ { body: "A", position: 0 }, { body: "B", position: 1 } ])
+    end
+end

--- a/test/controllers/messages/polls_controller_test.rb
+++ b/test/controllers/messages/polls_controller_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class Messages::PollsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in :david
+    @poll = create_poll
+    @message = @poll.message
+  end
+
+  test "update edits poll before votes" do
+    patch message_poll_url(@message), params: {
+      poll: {
+        question: "Updated?",
+        options_attributes: {
+          "0" => { id: @poll.options.first.id, body: "Yes", position: 0 },
+          "1" => { id: @poll.options.second.id, body: "No", position: 1 }
+        }
+      }
+    }
+
+    assert_redirected_to room_message_url(@message.room, @message)
+    assert_equal "Updated?", @poll.reload.question_plain_text
+    assert_equal [ "Yes", "No" ], @poll.options.pluck(:body)
+  end
+
+  test "update after votes edits question only" do
+    @poll.votes.create!(poll_option: @poll.options.first, voter: users(:david))
+
+    patch message_poll_url(@message), params: {
+      poll: {
+        question: "Updated?",
+        options_attributes: {
+          "0" => { id: @poll.options.first.id, body: "Yes", position: 0 },
+          "1" => { id: @poll.options.second.id, body: "No", position: 1 }
+        }
+      }
+    }
+
+    assert_redirected_to room_message_url(@message.room, @message)
+    assert_equal "Updated?", @poll.reload.question_plain_text
+    assert_equal [ "Yep", "Nope" ], @poll.options.pluck(:body)
+  end
+
+  test "update blocked when closed" do
+    @poll.close!
+
+    patch message_poll_url(@message), params: { poll: { question: "Updated?" } }
+
+    assert_response :unprocessable_entity
+    assert_equal "Ready?", @poll.reload.question_plain_text
+  end
+
+  test "close closes poll when user can administer" do
+    patch close_message_poll_url(@message, format: :turbo_stream)
+
+    assert_response :ok
+    assert @poll.reload.closed?
+  end
+
+  test "close forbidden for non-admin and non-author" do
+    sign_in :kevin
+
+    patch close_message_poll_url(@message, format: :turbo_stream)
+
+    assert_response :forbidden
+    assert_includes response.body, "Only the poll creator or an admin can edit or close this poll."
+    assert_not @poll.reload.closed?
+  end
+
+  test "edit forbidden for non-admin and non-author shows an alert" do
+    sign_in :kevin
+
+    get edit_message_poll_url(@message, format: :turbo_stream)
+
+    assert_response :forbidden
+    assert_includes response.body, "Only the poll creator or an admin can edit or close this poll."
+  end
+
+  test "update forbidden for non-admin and non-author shows an alert" do
+    sign_in :kevin
+
+    patch message_poll_url(@message, format: :turbo_stream), params: { poll: { question: "Updated?" } }
+
+    assert_response :forbidden
+    assert_includes response.body, "Only the poll creator or an admin can edit or close this poll."
+    assert_equal "Ready?", @poll.reload.question_plain_text
+  end
+
+  private
+    def create_poll
+      message = rooms(:designers).messages.create!(creator: users(:jason), body: "", client_message_id: SecureRandom.uuid)
+      message.create_poll!(question: "Ready?", options_attributes: [ { body: "Yep", position: 0 }, { body: "Nope", position: 1 } ])
+    end
+end

--- a/test/controllers/messages/polls_controller_test.rb
+++ b/test/controllers/messages/polls_controller_test.rb
@@ -50,6 +50,38 @@ class Messages::PollsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Ready?", @poll.reload.question_plain_text
   end
 
+  test "edit renders delete-only management when closed" do
+    @poll.close!
+
+    get edit_message_poll_url(@message)
+
+    assert_response :success
+    assert_select "h2", text: "Manage poll"
+    assert_select "form[action='#{room_message_path(@message.room, @message)}']"
+    assert_select "button", text: /Delete poll|/
+  end
+
+  test "delete poll destroys message and poll" do
+    assert_difference -> { Message.count }, -1 do
+      assert_difference -> { Poll.count }, -1 do
+        delete room_message_url(@message.room, @message, format: :turbo_stream)
+        assert_response :success
+      end
+    end
+  end
+
+  test "delete closed poll with votes destroys message and poll" do
+    @poll.votes.create!(poll_option: @poll.options.first, voter: users(:david))
+    @poll.close!
+
+    assert_difference -> { Message.count }, -1 do
+      assert_difference -> { Poll.count }, -1 do
+        delete room_message_url(@message.room, @message, format: :turbo_stream)
+        assert_response :success
+      end
+    end
+  end
+
   test "close closes poll when user can administer" do
     patch close_message_poll_url(@message, format: :turbo_stream)
 

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -126,6 +126,25 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "legacy message edit path does not render poll editor" do
+    message = rooms(:designers).messages.create!(creator: users(:jason), client_message_id: SecureRandom.uuid)
+    message.create_poll!(question: "Ready?", options_attributes: [ { body: "Yep", position: 0 }, { body: "Nope", position: 1 } ])
+
+    get edit_room_message_url(message.room, message)
+
+    assert_response :unprocessable_entity
+  end
+
+  test "legacy message edit path remains forbidden for poll non-admin non-creator" do
+    sign_in :kevin
+    message = rooms(:designers).messages.create!(creator: users(:jason), client_message_id: SecureRandom.uuid)
+    message.create_poll!(question: "Ready?", options_attributes: [ { body: "Yep", position: 0 }, { body: "Nope", position: 1 } ])
+
+    get edit_room_message_url(message.room, message)
+
+    assert_response :forbidden
+  end
+
   test "mentioning a bot triggers a webhook" do
     WebMock.stub_request(:post, webhooks(:bender).url).to_return(status: 200)
 

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -113,7 +113,7 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
 
     follow_redirect!
 
-    assert_select "a[aria-label='Edit poll'][hidden][data-poll-actions-target='adminAction']"
+    assert_select "a[aria-label='Manage poll'][hidden][data-poll-actions-target='adminAction']"
     assert_select "form[action='#{close_message_poll_path(Message.last)}'][hidden][data-poll-actions-target='adminAction']"
   end
 

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -30,6 +30,22 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "poll-client-id", Message.last.client_message_id
   end
 
+  test "create multi-select poll" do
+    post room_polls_url(@room), params: {
+      poll: {
+        question: "Pick any?",
+        multi_select: "1",
+        options_attributes: {
+          "0" => { body: "A", position: 0 },
+          "1" => { body: "B", position: 1 }
+        }
+      }
+    }
+
+    assert_redirected_to room_url(@room)
+    assert_predicate Poll.last, :multi_select?
+  end
+
   test "new poll renders as a full page" do
     get new_room_poll_url(@room)
 

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -1,0 +1,153 @@
+require "test_helper"
+
+class PollsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "once.campfire.test"
+    sign_in :david
+    @room = rooms(:designers)
+  end
+
+  test "create poll" do
+    assert_difference -> { Poll.count }, 1 do
+      assert_difference -> { Message.count }, 1 do
+        post room_polls_url(@room), params: {
+          poll: {
+            question: "Ship it?",
+            options_attributes: {
+              "0" => { body: "Yes", position: 0 },
+              "1" => { body: "No", position: 1 }
+            }
+          },
+          message: {
+            client_message_id: "poll-client-id"
+          }
+        }
+      end
+    end
+
+    assert_redirected_to room_url(@room)
+    assert_equal "poll", Message.last.content_type
+    assert_equal "poll-client-id", Message.last.client_message_id
+  end
+
+  test "new poll renders as a full page" do
+    get new_room_poll_url(@room)
+
+    assert_response :success
+    assert_select "turbo-frame#composer-modal", false
+    assert_select "#message-area .poll-editor"
+  end
+
+  test "new poll reuses client message id until create succeeds" do
+    get new_room_poll_url(@room)
+    first_client_message_id = css_select("input[name='message[client_message_id]']").first["value"]
+
+    get new_room_poll_url(@room)
+
+    assert_select "input[name='message[client_message_id]'][value='#{first_client_message_id}']"
+
+    post room_polls_url(@room), params: valid_poll_params(first_client_message_id)
+    assert_redirected_to room_url(@room)
+
+    get new_room_poll_url(@room)
+    next_client_message_id = css_select("input[name='message[client_message_id]']").first["value"]
+
+    assert_not_equal first_client_message_id, next_client_message_id
+  end
+
+  test "duplicate poll create with same client message id is ignored" do
+    params = valid_poll_params("duplicate-client-id")
+
+    post room_polls_url(@room), params: params
+
+    assert_no_difference -> { Message.count } do
+      assert_no_difference -> { Poll.count } do
+        post room_polls_url(@room), params: params
+      end
+    end
+  end
+
+  test "poll question renders rich text" do
+    post room_polls_url(@room), params: {
+      poll: {
+        question: "<ul><li>Mobile</li><li>Desktop</li></ul>",
+        options_attributes: {
+          "0" => { body: "Yes", position: 0 },
+          "1" => { body: "No", position: 1 }
+        }
+      }
+    }
+
+    follow_redirect!
+
+    assert_select ".poll__question li", text: "Mobile"
+    assert_select ".poll__question li", text: "Desktop"
+  end
+
+  test "created poll renders edit and close actions" do
+    post room_polls_url(@room), params: {
+      poll: {
+        question: "Ship it?",
+        options_attributes: {
+          "0" => { body: "Yes", position: 0 },
+          "1" => { body: "No", position: 1 }
+        }
+      }
+    }
+
+    follow_redirect!
+
+    assert_select "a[aria-label='Edit poll'][hidden][data-poll-actions-target='adminAction']"
+    assert_select "form[action='#{close_message_poll_path(Message.last)}'][hidden][data-poll-actions-target='adminAction']"
+  end
+
+  test "invalid create does not persist message" do
+    assert_no_difference -> { Poll.count } do
+      assert_no_difference -> { Message.count } do
+        post room_polls_url(@room), params: {
+          poll: {
+            question: "",
+            options_attributes: {
+              "0" => { body: "Only one", position: 0 }
+            }
+          }
+        }
+      end
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "invalid create preserves client message id" do
+    post room_polls_url(@room), params: {
+      poll: {
+        question: "",
+        options_attributes: {
+          "0" => { body: "Only one", position: 0 }
+        }
+      },
+      message: {
+        client_message_id: "retry-client-id"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "input[name='message[client_message_id]'][value='retry-client-id']"
+  end
+
+  private
+    def valid_poll_params(client_message_id)
+      {
+        poll: {
+          question: "Ship it?",
+          options_attributes: {
+            "0" => { body: "Yes", position: 0 },
+            "1" => { body: "No", position: 1 }
+          }
+        },
+        message: {
+          client_message_id: client_message_id
+        }
+      }
+    end
+end

--- a/test/models/poll_test.rb
+++ b/test/models/poll_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class PollTest < ActiveSupport::TestCase
+  test "requires question and at least two options" do
+    poll = build_poll(question: "", options: [ "One" ])
+
+    assert_not poll.valid?
+    assert_includes poll.errors[:question], "can't be blank"
+    assert_includes poll.errors[:options], "must have between 2 and 10 options"
+  end
+
+  test "question can include mentions" do
+    poll = build_poll(question: "Hi #{mention_attachment_for(:david)}", options: [ "One", "Two" ])
+
+    assert poll.valid?
+    assert_equal [ users(:david) ], poll.message.mentionees
+  end
+
+  test "vote option must belong to poll" do
+    poll = create_poll
+    other_poll = create_poll
+    vote = poll.votes.build(voter: users(:david), poll_option: other_poll.options.first)
+
+    assert_not vote.valid?
+    assert_includes vote.errors[:poll_option], "must belong to poll"
+  end
+
+  private
+    def create_poll
+      message = rooms(:designers).messages.create!(creator: users(:jason), body: "", client_message_id: SecureRandom.uuid)
+      message.create_poll!(question: "Which one?", options_attributes: [ { body: "A", position: 0 }, { body: "B", position: 1 } ])
+    end
+
+    def build_poll(question:, options:)
+      message = Message.new(room: rooms(:designers), creator: users(:jason), client_message_id: SecureRandom.uuid)
+      message.build_poll(
+        question:,
+        options_attributes: options.each_with_index.map { |body, i| { body:, position: i } }
+      )
+    end
+end

--- a/test/system/polling_messages_test.rb
+++ b/test/system/polling_messages_test.rb
@@ -1,0 +1,20 @@
+require "application_system_test_case"
+
+class PollingMessagesTest < ApplicationSystemTestCase
+  setup do
+    sign_in "kevin@37signals.com"
+    join_room rooms(:designers)
+  end
+
+  test "creating and voting on a poll" do
+    click_on "Create poll"
+    fill_in_rich_text_area "poll_question", with: "What should we ship next?"
+    fill_in "poll[options_attributes][0][body]", with: "Mobile"
+    fill_in "poll[options_attributes][1][body]", with: "Desktop"
+    click_on "Create poll"
+
+    assert_selector ".poll", text: "What should we ship next?"
+    click_on "Mobile"
+    assert_selector ".poll__results", text: "1 vote", wait: 5
+  end
+end


### PR DESCRIPTION
This pull request introduces a comprehensive poll feature to the application, allowing users to create, vote on, and administer polls attached to messages. It adds new models, controllers, views, Stimulus controllers, and styles, as well as updates existing models and helpers to support poll functionality. The changes include robust validation, real-time updates, and admin controls for polls.

**Poll Feature Implementation**

* Added new models to support polls:
  * `Poll` model with question, options, multi-select, and open/closed state, including validations for question length and option count.
  * `PollOption` model for poll choices, with validations and association to `Poll`.
  * `PollVote` model for tracking user votes, ensuring uniqueness and correct associations, and updating message timestamps on changes.
* Integrated poll associations and logic into the `Message` model:
  * Messages can now have one poll; added relevant scopes and validations. [[1]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR8-R9) [[2]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR24-R27) [[3]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR38)
  * Updated `plain_text_body` and `content_type` to handle polls. [[1]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR24-R27) [[2]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR38)
  * Adjusted message creation to support poll attachments.

**Poll Controllers and Parameters**

* Introduced controllers for poll creation, voting, and administration:
  * `PollsController` for creating new polls with session-based client message IDs and error handling.
  * `Messages::PollsController` for editing, updating, and closing polls, with admin checks and Turbo Stream updates.
  * `Messages::PollVotesController` for casting and removing votes, handling multi-select, and broadcasting updates.
* Added a `PollParameters` concern for strong parameter handling of poll forms.

**Frontend Enhancements for Polls**

* Added new Stimulus controllers to handle poll forms, options, and admin actions:
  * `poll_form_controller.js` for client-side question validation.
  * `poll_options_controller.js` for dynamic option add/remove and position normalization.
  * `poll_actions_controller.js` for revealing admin actions based on user permissions.
* Created new CSS for poll components and improved flash message styles:
  * Added `polls.css` for layout, results, ballot, and editor styling.
  * Enhanced `flash.css` for better alignment, animations, and alert/message distinction. [[1]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33R2-R5) [[2]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33L12) [[3]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33R26-R38)
  * Updated flash message partial for accessible alert display.

**Message and Poll Presentation**

* Updated message helper to render polls using a dedicated partial.
* Improved mentionee extraction to include users mentioned in poll questions.
* Adjusted message pagination to include poll data for efficient loading.
* Prevented editing of poll messages through the standard message edit action.

---

**References:**  
[[1]](diffhunk://#diff-6490cbd2800c2c0c4edd81cc11049d665ceeed808f7fbde902f12306e6bf1b38R1-R55) [[2]](diffhunk://#diff-61e411d4c5005daa04b951292689ba9d00eff2d9d660ea15f2a45f1791828335R1-R7) [[3]](diffhunk://#diff-90558174140e12dbe7647985c17d129c503b3a8eb101f82d19c66f39195da701R1-R26) [[4]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR8-R9) [[5]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR24-R27) [[6]](diffhunk://#diff-684a16c1b0b4c099fcdfeed95b1820e11fef629fe332ec7ce6a8c600331dd06dR38) [[7]](diffhunk://#diff-59a44dd53a5b24584d4943985984caaece167a2ee0ada32a03e9be446d4ff743L15-R15) [[8]](diffhunk://#diff-4dd994633d659e50866fa53cf11949c7f72818345df62ebf9296565d235693f9R1-R61) [[9]](diffhunk://#diff-8e466036b70d26d019e73f0bfdde5c446138dd706f06a90489654414826628c6R1-R58) [[10]](diffhunk://#diff-5f970004570429e7cbadd970b146dd6a02f780ef687e247a0287007a6cf005f3R1-R73) [[11]](diffhunk://#diff-8bdd974cb431bbeb451eb6a0e650f5630507572ef9f97de92adc4d6136a4fe81R1-R8) [[12]](diffhunk://#diff-d815eaf9ea1db2be1ec357c017174183714a42f14d0f87c1bddd9fb83be4b5a2R1-R18) [[13]](diffhunk://#diff-7826b5771116b13e344e16c2cd88369c9f5426ae6a66c5087d0421d7a5c4cfc3R1-R62) [[14]](diffhunk://#diff-9d6eab6447e35f8e1791a8701b07c6e7c9603d0e1ca9f887819ddf03815f80ecR1-R16) [[15]](diffhunk://#diff-1819acfa83a3240dbf1d68cb38c2d2132bcc8736db8f2353351177d321b1405aR1-R155) [[16]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33R2-R5) [[17]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33L12) [[18]](diffhunk://#diff-c575cf4cef7a9b21c2d2a858bda0aff16af84f090501370c138bc273572dcd33R26-R38) [[19]](diffhunk://#diff-f0342b015bf6432993c0fd46ef2b4ed579303b635121e8630f78f83309f4ed18R1-R19) [[20]](diffhunk://#diff-7cb3f33ed8cd7f9d71058dc2794a0f49c4ff135156fac2c3318840fdd2431040R59-R60) [[21]](diffhunk://#diff-25cab7547fabe41ce3cf0dcb91b1c7023d61fbdacdb8dc1cf8dab05dc518f741L10-R13) [[22]](diffhunk://#diff-9b58332ea76756301b1aafeacfb0659d1244ba014947602b0e0bf2d0f2921d26R60-R67) [[23]](diffhunk://#diff-9b58332ea76756301b1aafeacfb0659d1244ba014947602b0e0bf2d0f2921d26R34)