### PR TITLE
Require authentication for ActiveStorage direct-upload write endpoints

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -17,5 +17,15 @@ ActiveSupport.on_load(:active_storage_blob) do
 
   ActiveStorage::DiskController.include Rails.application.routes.url_helpers
   ActiveStorage::DiskController.include Authentication
-  ActiveStorage::DiskController.skip_before_action :require_authentication, :deny_bots, only: :show
+
+  # Blob serving (#show) stays public so signed-token attachment URLs keep
+  # resolving for unauthenticated and bot clients alike.
+  ActiveStorage::DiskController.allow_unauthenticated_access only: :show
+  ActiveStorage::DiskController.allow_bot_access only: :show
+
+  # Including Authentication re-adds protect_from_forgery, but Active Storage's
+  # direct-upload service PUT (#update) carries only signed service headers and
+  # no authenticity token. Re-exempt it from CSRF so authenticated uploads can
+  # still store bytes; the signed URL token and the session check remain.
+  ActiveStorage::DiskController.skip_forgery_protection only: :update
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -2,4 +2,20 @@ ActiveSupport.on_load(:active_storage_blob) do
   ActiveStorage::DiskController.after_action only: :show do
     response.set_header("Cache-Control", "max-age=3600, public")
   end
+
+  # Gate the ActiveStorage write path behind app authentication. These endpoints
+  # ship unauthenticated by Rails default; Campfire never uses direct upload for
+  # legit attachments (those go through MessagesController#create, and Trix file
+  # drops are disabled in the composer). Requiring a session on the write actions
+  # blocks anonymous blob writes and disk-fill while leaving blob serving public.
+  #
+  # ActiveStorage controllers live in ActiveStorage::Engine, so they see the
+  # engine's url helpers, not the main app's. Include the application helpers
+  # first so Authentication#request_authentication can redirect to new_session_url.
+  ActiveStorage::DirectUploadsController.include Rails.application.routes.url_helpers
+  ActiveStorage::DirectUploadsController.include Authentication # only action: #create
+
+  ActiveStorage::DiskController.include Rails.application.routes.url_helpers
+  ActiveStorage::DiskController.include Authentication
+  ActiveStorage::DiskController.skip_before_action :require_authentication, :deny_bots, only: :show
 end

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -35,14 +35,16 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "disk update requires authentication" do
-    put direct_upload_url_for("hello"), params: "hello", headers: { "Content-Type" => "text/plain" }
+    _blob, url = direct_upload_url_for("hello")
+
+    put url, params: "hello", headers: { "Content-Type" => "text/plain" }
 
     assert_redirected_to new_session_url
   end
 
   test "disk update stores bytes for an authenticated session without a CSRF token" do
     sign_in :david
-    url = direct_upload_url_for("hello")
+    blob, url = direct_upload_url_for("hello")
 
     # Forgery protection is off in test by default; turn it on so this proves the
     # signed-token service PUT stays CSRF-exempt even when the concern re-arms it.
@@ -51,6 +53,7 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
     end
 
     assert_response :no_content
+    assert_equal "hello", blob.download
   end
 
   private
@@ -64,9 +67,10 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
       blob = ActiveStorage::Blob.create_before_direct_upload! \
         filename: "hello.txt", byte_size: content.bytesize, \
         checksum: Digest::MD5.base64digest(content), content_type: "text/plain"
-      ActiveStorage::Current.set(url_options: { host: "once.campfire.test", protocol: "http" }) do
+      url = ActiveStorage::Current.set(url_options: { host: "once.campfire.test", protocol: "http" }) do
         blob.service_url_for_direct_upload
       end
+      [ blob, url ]
     end
 
     def with_forgery_protection

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -34,10 +34,46 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
     assert_response :success
   end
 
+  test "disk update requires authentication" do
+    put direct_upload_url_for("hello"), params: "hello", headers: { "Content-Type" => "text/plain" }
+
+    assert_redirected_to new_session_url
+  end
+
+  test "disk update stores bytes for an authenticated session without a CSRF token" do
+    sign_in :david
+    url = direct_upload_url_for("hello")
+
+    # Forgery protection is off in test by default; turn it on so this proves the
+    # signed-token service PUT stays CSRF-exempt even when the concern re-arms it.
+    with_forgery_protection do
+      put url, params: "hello", headers: { "Content-Type" => "text/plain" }
+    end
+
+    assert_response :no_content
+  end
+
   private
     def blob_params
       content = "hello"
       { filename: "hello.txt", byte_size: content.bytesize, content_type: "text/plain", \
         checksum: Digest::MD5.base64digest(content) }
+    end
+
+    def direct_upload_url_for(content)
+      blob = ActiveStorage::Blob.create_before_direct_upload! \
+        filename: "hello.txt", byte_size: content.bytesize, \
+        checksum: Digest::MD5.base64digest(content), content_type: "text/plain"
+      ActiveStorage::Current.set(url_options: { host: "once.campfire.test", protocol: "http" }) do
+        blob.service_url_for_direct_upload
+      end
+    end
+
+    def with_forgery_protection
+      original = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      yield
+    ensure
+      ActionController::Base.allow_forgery_protection = original
     end
 end

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -26,9 +26,10 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
   test "disk show stays reachable without authentication" do
     blob = ActiveStorage::Blob.create_and_upload! \
       io: StringIO.new("hello"), filename: "hello.txt", content_type: "text/plain"
-    ActiveStorage::Current.url_options = { host: "once.campfire.test", protocol: "http" }
 
-    get blob.url
+    ActiveStorage::Current.set(url_options: { host: "once.campfire.test", protocol: "http" }) do
+      get blob.url
+    end
 
     assert_response :success
   end

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "once.campfire.test"
+  end
+
+  test "create requires authentication" do
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      post rails_direct_uploads_url, params: { blob: blob_params }
+    end
+
+    assert_redirected_to new_session_url
+  end
+
+  test "create succeeds for an authenticated session" do
+    sign_in :david
+
+    assert_difference -> { ActiveStorage::Blob.count }, 1 do
+      post rails_direct_uploads_url, params: { blob: blob_params }
+    end
+
+    assert_response :success
+  end
+
+  test "disk show stays reachable without authentication" do
+    blob = ActiveStorage::Blob.create_and_upload! \
+      io: StringIO.new("hello"), filename: "hello.txt", content_type: "text/plain"
+    ActiveStorage::Current.url_options = { host: "once.campfire.test", protocol: "http" }
+
+    get blob.url
+
+    assert_response :success
+  end
+
+  private
+    def blob_params
+      content = "hello"
+      { filename: "hello.txt", byte_size: content.bytesize, content_type: "text/plain", \
+        checksum: Digest::MD5.base64digest(content) }
+    end
+end


### PR DESCRIPTION
## What

ActiveStorage's direct-upload endpoints ship unauthenticated by Rails default — `ActiveStorage::DirectUploadsController` and `ActiveStorage::DiskController` inherit from `ActionController::Base`, so they bypass the app's `Authentication` concern. This gates the **write path** behind an authenticated session as defense-in-depth.

## Why it's low-risk

Campfire never uses direct upload for legitimate attachments:

- Message attachments flow through `MessagesController#create`, which is already authenticated.
- Trix file drops are disabled in the composer (`permitted_attachment_types` is opengraph-embed only).

So no legitimate flow regresses. Even if a rich-text surface did direct-upload, its same-origin XHR carries the session cookie and passes auth.

## Scope

- Gates `DirectUploadsController#create` (mints a blob + signed PUT URL) and `DiskController#update` (writes bytes) — the write path. Gating `#create` alone already breaks the chain (the PUT URL is server-HMAC-signed and can't be minted without it); gating `#update` is belt-and-suspenders.
- Leaves blob **serving** untouched: `DiskController#show` keeps its auth skip, and `Blobs`/`Representations` are not modified. Message attachments and `/account/logo` keep loading.
- Because these controllers live in `ActiveStorage::Engine` and only see the engine's url helpers, the application route helpers are included so the `Authentication` concern can redirect to `new_session_url` on failure (302 → write blocked).

## Test

`test/controllers/active_storage/direct_uploads_controller_test.rb`:

- unauthenticated `POST /rails/active_storage/direct_uploads` → redirect to login, no blob created
- authenticated POST → succeeds
- `DiskController#show` stays reachable without auth (read-path carve-out)