### PR TITLE
Return consistent redirect on duplicate registration

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
     start_new_session_for @user
     redirect_to root_url
   rescue ActiveRecord::RecordNotUnique
-    redirect_to new_session_url(email_address: user_params[:email_address])
+    redirect_to new_session_url
   end
 
   def show


### PR DESCRIPTION
When a user attempts to register with an email address that is already taken, the RecordNotUnique rescue redirects to /session/new?email_address=<email>. A successful registration redirects to /. The differing redirect targets reveal whether an address is registered.

This PR removes the email_address parameter from the duplicate-registration redirect, making both paths return an opaque redirect without leaking registration state. The existing-user flow still lands on the sign-in page; it just no longer pre-fills the email field.