### PR TITLE
Bump json to 2.20.0 (CVE-2026-54696)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.13.2)
+    json (2.20.0)
     jwt (3.2.0)
       base64
     kredis (1.8.0)


### PR DESCRIPTION
Bumps `json` to **2.20.0** to resolve **CVE-2026-54696** (GHSA-x2f5-4prf-w687).

`json` 2.9.0–2.19.8 has a heap buffer overflow in the generator when streaming
an oversized object to an IO (`JSON.dump(obj, io)` / `JSON::State#generate(obj, io)`)
where an attacker-controlled string sits near the 16 KB buffer boundary — a
reliable process crash / DoS. Fixed upstream in 2.19.9; this bumps to the current
2.20.0 line already used by other apps here.

Lockfile-only change via `bundle update json --conservative` — no other gems moved.

- Advisory: https://nvd.nist.gov/vuln/detail/CVE-2026-54696
- Release: https://github.com/ruby/json/releases/tag/v2.19.9
