### PR TITLE
Add ONCE backup and restore hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ ENV HTTP_WRITE_TIMEOUT=300
 COPY --from=build --chown=rails:rails /usr/local/bundle /usr/local/bundle
 COPY --from=build --chown=rails:rails /rails /rails
 
+# Install ONCE backup/restore hooks
+COPY --chmod=755 hooks /hooks
+
 # Set version and revision
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION

--- a/hooks/post-restore
+++ b/hooks/post-restore
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+db_name="${RAILS_ENV:-production}.sqlite3"
+snapshot="/rails/storage/backups/$db_name"
+db="/rails/storage/db/$db_name"
+
+if [ -f "$snapshot" ]; then
+  mkdir -p "$(dirname "$db")"
+  cp "$snapshot" "$db"
+  rm -f "$db-wal" "$db-shm"
+fi

--- a/hooks/pre-backup
+++ b/hooks/pre-backup
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /rails/script/admin/prepare-backup


### PR DESCRIPTION
By default, ONCE pauses the application container when taking a backup. This guarantees a consistent snapshot of the data, but for a large installation and/or a slow destination path (like a network mount), that pause could be a bit disruptive to live traffic.

But ONCE also supports a pause-free path: if a `pre-backup` hook is present in the container, ONCE will run that and skip the pause. So by supplying necessary hooks, we can avoid any disruption from backups.

- `pre-backup` runs the existing script/admin/prepare-backup, which uses SQLite's online backup API to get a consistent snapshop.

- `post-restore` moves our snaphotted file back into place, and removes the orphaned sidecar files