### PR TITLE
Serve custom styles from a dedicated text/css route

### DIFF
--- a/app/controllers/accounts/custom_styles_controller.rb
+++ b/app/controllers/accounts/custom_styles_controller.rb
@@ -1,5 +1,14 @@
 class Accounts::CustomStylesController < ApplicationController
-  before_action :ensure_can_administer, :set_account
+  allow_unauthenticated_access only: :show
+  before_action :ensure_can_administer, :set_account, except: :show
+
+  def show
+    if stale?(etag: Current.account)
+      expires_in 5.minutes, public: true, stale_while_revalidate: 1.week
+
+      render plain: Current.account&.custom_styles.to_s, content_type: "text/css"
+    end
+  end
 
   def edit
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,12 +12,6 @@ module ApplicationHelper
     end
   end
 
-  def custom_styles_tag
-    if custom_styles = Current.account&.custom_styles
-      tag.style(custom_styles.to_s.html_safe, data: { turbo_track: "reload" })
-    end
-  end
-
   def body_classes
     [ @body_class, admin_body_class, account_logo_body_class ].compact.join(" ")
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <%= tag.link rel: "apple-touch-icon", href: fresh_account_logo_path %>
 
     <%= stylesheet_link_tag :all, "data-turbo-track": "reload" %>
-    <%= custom_styles_tag %>
+    <%= tag.link rel: "stylesheet", href: fresh_custom_styles_path, data: { turbo_track: "reload" } %>
 
     <%= javascript_importmap_tags %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   end
 
   direct :fresh_custom_styles do |options|
-    route_for :account_custom_styles, v: Current.account&.updated_at&.to_fs(:number)
+    route_for :account_custom_styles, v: Current.account&.updated_at&.to_fs(:epoch)
   end
 
   get "join/:join_code", to: "users#new", as: :join

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,16 @@ Rails.application.routes.draw do
 
       resource :join_code, only: :create
       resource :logo, only: %i[ show destroy ]
-      resource :custom_styles, only: %i[ edit update ]
+      resource :custom_styles, only: %i[ show edit update ]
     end
   end
 
   direct :fresh_account_logo do |options|
     route_for :account_logo, v: Current.account&.updated_at&.to_fs(:number), size: options[:size]
+  end
+
+  direct :fresh_custom_styles do |options|
+    route_for :account_custom_styles, v: Current.account&.updated_at&.to_fs(:number)
   end
 
   get "join/:join_code", to: "users#new", as: :join

--- a/test/controllers/accounts/custom_styles_controller_test.rb
+++ b/test/controllers/accounts/custom_styles_controller_test.rb
@@ -5,6 +5,34 @@ class Accounts::CustomStylesControllerTest < ActionDispatch::IntegrationTest
     sign_in :david
   end
 
+  test "show serves custom styles as plain CSS" do
+    accounts(:signal).update! custom_styles: ":root { --color-text: red; }"
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+    assert_equal ":root { --color-text: red; }", @response.body
+  end
+
+  test "show is accessible without authentication" do
+    accounts(:signal).update! custom_styles: ":root { --color-text: red; }"
+    reset!
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+  end
+
+  test "show serves markup verbatim as inert CSS text, never HTML" do
+    payload = "</style><script>alert(1)</script>"
+    accounts(:signal).update! custom_styles: payload
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+    assert_equal payload, @response.body
+  end
+
   test "edit" do
     get edit_account_custom_styles_url
     assert_response :ok

--- a/test/system/custom_styles_xss_test.rb
+++ b/test/system/custom_styles_xss_test.rb
@@ -1,0 +1,39 @@
+require "application_system_test_case"
+
+class CustomStylesXssTest < ApplicationSystemTestCase
+  # A stored payload that breaks out of an inline <style> context and executes
+  # as HTML. Rendered inline (the old behavior) this <script> runs and sets the
+  # flag; delivered as an external text/css stylesheet it is inert text.
+  PAYLOAD = %(</style><script>window.__xss_fired = true</script>)
+
+  setup do
+    accounts(:signal).update!(custom_styles: PAYLOAD)
+    sign_in "jz@37signals.com"
+  end
+
+  test "custom styles payload loads as a stylesheet and never executes" do
+    # (a) custom styles arrive via an external stylesheet link, not inline markup
+    assert_selector "link[rel='stylesheet'][href*='custom_styles']", visible: false
+
+    # (b) the payload's <script> never executed — no breakout from CSS context
+    assert_nil evaluate_script("window.__xss_fired")
+
+    # (b') and it injected no live <script> element into the document
+    assert_no_selector "script", text: "__xss_fired", visible: false
+
+    # (c) the browser fetched the payload verbatim as text/css, so it is styled,
+    #     never parsed as HTML
+    fetched = page.evaluate_async_script(<<~JS)
+      var done = arguments[arguments.length - 1];
+      var href = document.querySelector("link[rel='stylesheet'][href*='custom_styles']").href;
+      fetch(href).then(function(r) {
+        return r.text().then(function(body) {
+          done({ type: r.headers.get("content-type"), body: body });
+        });
+      });
+    JS
+
+    assert_includes fetched["type"], "text/css"
+    assert_includes fetched["body"], PAYLOAD
+  end
+end

--- a/test/system/custom_styles_xss_test.rb
+++ b/test/system/custom_styles_xss_test.rb
@@ -12,6 +12,11 @@ class CustomStylesXssTest < ApplicationSystemTestCase
   end
 
   test "custom styles payload loads as a stylesheet and never executes" do
+    # Navigate to the page under test explicitly (matching the writebook
+    # sibling) rather than leaning on the post-login landing page — otherwise
+    # this coverage could silently evaporate if that landing changes.
+    visit root_url
+
     # (a) custom styles arrive via an external stylesheet link, not inline markup
     assert_selector "link[rel='stylesheet'][href*='custom_styles']", visible: false
 


### PR DESCRIPTION
## Finding

Admin-authored `Account#custom_styles` is rendered inline into every page by `custom_styles_tag`, which marks the raw value `html_safe` inside a `<style>` element. Because the value lands in an HTML context, a stored payload of

```
</style><script>alert(1)</script>
```

closes the style element and executes as script — a verified stored XSS (campaign finding oc-C3), delivered to everyone who loads the app, including unauthenticated visitors on instances with public rooms.

## Fix

Move the styles off the HTML page entirely, so there is no HTML context to break out of — mirroring the existing account-logo pattern:

- `Accounts::CustomStyles#show` gets `allow_unauthenticated_access`, guards with `stale?(etag: Current.account)`, sets `expires_in 5.minutes, public: true, stale_while_revalidate: 1.week`, and renders `custom_styles` verbatim as `text/css` — the same shape as `Accounts::LogosController#show`.
- A `direct :fresh_custom_styles` route appends `v=account.updated_at` (the `fresh_account_logo` idiom) so style edits bust caches immediately.
- The layout replaces the inline `<style>` with `<link rel="stylesheet" href="<%= fresh_custom_styles_path %>" data-turbo-track="reload">`.
- The dead `custom_styles_tag` helper is removed.

Capability-preserving: admins author exactly the same CSS; only the transport changes. In a `text/css` document, markup is inert text — the breakout is closed by construction rather than by filtering.

Part of the stored-XSS eradication campaign covering ONCE apps (companion PR in writebook).

## Verification

- `bin/rails runner 'Rails.application.routes.recognize_path("/account/custom_styles", method: :get)'` → `accounts/custom_styles#show`
- New controller tests: response is `text/css`; the `</style><script>` payload is served byte-for-byte verbatim as CSS text; route is reachable without authentication.
- Full test suite: 314 runs, 0 failures, 0 errors (1 skip, confirmed pre-existing on a clean baseline).