### PR TITLE
Allow bots to update and destroy their own messages

### DIFF
--- a/app/controllers/messages/by_bots_controller.rb
+++ b/app/controllers/messages/by_bots_controller.rb
@@ -1,9 +1,11 @@
 class Messages::ByBotsController < MessagesController
   include RawRequestBody
 
-  allow_bot_access only: %i[ index create ]
+  allow_bot_access only: %i[ index create update destroy ]
 
   before_action :set_room
+  before_action :set_message, only: %i[ update destroy ]
+  before_action :ensure_can_administer, only: %i[ update destroy ]
   before_action :ensure_body_or_attachment_present, only: :create
 
   def index
@@ -14,6 +16,18 @@ class Messages::ByBotsController < MessagesController
   def create
     super
     head :created, location: message_url(@message)
+  end
+
+  # ensure_can_administer still applies, and can_administer? only grants access to
+  # a record the user created, so a bot key reaches that bot's own messages and no others.
+  def update
+    update_message
+    head :ok
+  end
+
+  def destroy
+    super
+    head :no_content
   end
 
   private

--- a/app/controllers/messages/by_bots_controller.rb
+++ b/app/controllers/messages/by_bots_controller.rb
@@ -18,13 +18,6 @@ class Messages::ByBotsController < MessagesController
     head :created, location: message_url(@message)
   end
 
-  # ensure_can_administer still applies, and can_administer? only grants access to
-  # a record the user created, so a bot key reaches that bot's own messages and no others.
-  def update
-    update_message
-    head :ok
-  end
-
   def destroy
     super
     head :no_content

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -34,9 +34,7 @@ class MessagesController < ApplicationController
   end
 
   def update
-    @message.update!(message_params)
-
-    @message.broadcast_replace_to @room, :messages, target: [ @message, :presentation ], partial: "messages/presentation", attributes: { maintain_scroll: true }
+    update_message
     redirect_to room_message_url(@room, @message)
   end
 
@@ -48,6 +46,13 @@ class MessagesController < ApplicationController
   private
     def set_message
       @message = @room.messages.find(params[:id])
+    end
+
+    # Extracted so bots can reuse the update and its broadcast while answering with
+    # a status code instead of a redirect.
+    def update_message
+      @message.update!(message_params)
+      @message.broadcast_replace_to @room, :messages, target: [ @message, :presentation ], partial: "messages/presentation", attributes: { maintain_scroll: true }
     end
 
     def ensure_can_administer

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -34,8 +34,14 @@ class MessagesController < ApplicationController
   end
 
   def update
-    update_message
-    redirect_to room_message_url(@room, @message)
+    @message.update!(message_params)
+
+    @message.broadcast_replace_to @room, :messages, target: [ @message, :presentation ], partial: "messages/presentation", attributes: { maintain_scroll: true }
+
+    respond_to do |format|
+      format.html { redirect_to room_message_url(@room, @message) }
+      format.json { render :show }
+    end
   end
 
   def destroy
@@ -46,13 +52,6 @@ class MessagesController < ApplicationController
   private
     def set_message
       @message = @room.messages.find(params[:id])
-    end
-
-    # Extracted so bots can reuse the update and its broadcast while answering with
-    # a status code instead of a redirect.
-    def update_message
-      @message.update!(message_params)
-      @message.broadcast_replace_to @room, :messages, target: [ @message, :presentation ], partial: "messages/presentation", attributes: { maintain_scroll: true }
     end
 
     def ensure_can_administer

--- a/app/views/messages/by_bots/show.json.jbuilder
+++ b/app/views/messages/by_bots/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "messages/message", message: @message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
 
     nested do
       scope path: ":bot_key", as: :bot, defaults: { format: :json } do
-        resources :messages, controller: "messages/by_bots", only: %i[ index create ] do
+        resources :messages, controller: "messages/by_bots", only: %i[ index create update destroy ] do
           resources :boosts, controller: "messages/boosts/by_bots", only: :create
         end
       end

--- a/test/controllers/messages/by_bots_controller_test.rb
+++ b/test/controllers/messages/by_bots_controller_test.rb
@@ -158,6 +158,12 @@ class Messages::ByBotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal "Deployed.", message.reload.plain_text_body
+
+    json = JSON.parse(response.body)
+    assert_equal message.id, json["id"]
+    assert_equal "Deployed.", json["body"]["plain_text"]
+    assert_equal users(:bender).id, json["creator"]["id"]
+    assert_equal room_message_url(@room, message), json["url"]
   end
 
   test "update with UTF-8 content" do
@@ -167,6 +173,7 @@ class Messages::ByBotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal "Deployed 🚀!", message.reload.plain_text_body
+    assert_equal "Deployed 🚀!", JSON.parse(response.body)["body"]["plain_text"]
   end
 
   test "update can't touch a message the bot did not create" do

--- a/test/controllers/messages/by_bots_controller_test.rb
+++ b/test/controllers/messages/by_bots_controller_test.rb
@@ -148,4 +148,81 @@ class Messages::ByBotsControllerTest < ActionDispatch::IntegrationTest
     get room_messages_url(@room, bot_key: users(:bender).bot_key)
     assert_response :forbidden
   end
+
+  test "update" do
+    message = post_bot_message "Deploying..."
+
+    assert_no_difference -> { Message.count } do
+      patch room_bot_message_url(@room, users(:bender).bot_key, message), params: +"Deployed."
+    end
+
+    assert_response :ok
+    assert_equal "Deployed.", message.reload.plain_text_body
+  end
+
+  test "update with UTF-8 content" do
+    message = post_bot_message "Deploying..."
+
+    patch room_bot_message_url(@room, users(:bender).bot_key, message), params: +"Deployed 🚀!"
+
+    assert_response :ok
+    assert_equal "Deployed 🚀!", message.reload.plain_text_body
+  end
+
+  test "update can't touch a message the bot did not create" do
+    message = messages(:fourth)
+    original = message.plain_text_body
+
+    patch room_bot_message_url(@room, users(:bender).bot_key, message), params: +"Hijacked!"
+
+    assert_response :forbidden
+    assert_equal original, message.reload.plain_text_body
+  end
+
+  test "update is not found for a room the bot is not a member of" do
+    message = messages(:first)
+    original = message.plain_text_body
+
+    patch room_bot_message_url(rooms(:designers), users(:bender).bot_key, message), params: +"Hijacked!"
+
+    assert_response :not_found
+    assert_equal original, message.reload.plain_text_body
+  end
+
+  test "update can't be abused to edit messages as any user" do
+    message = messages(:fourth)
+    bot_key = "#{users(:jz).id}-"
+    original = message.plain_text_body
+
+    patch room_bot_message_url(@room, bot_key, message), params: +"Hijacked!"
+
+    assert_response :redirect
+    assert_equal original, message.reload.plain_text_body
+  end
+
+  test "destroy" do
+    message = post_bot_message "Deploying..."
+
+    assert_difference -> { Message.count }, -1 do
+      delete room_bot_message_url(@room, users(:bender).bot_key, message)
+    end
+
+    assert_response :no_content
+  end
+
+  test "destroy can't touch a message the bot did not create" do
+    message = messages(:fourth)
+
+    assert_no_difference -> { Message.count } do
+      delete room_bot_message_url(@room, users(:bender).bot_key, message)
+    end
+
+    assert_response :forbidden
+  end
+
+  private
+    def post_bot_message(body)
+      post room_bot_messages_url(@room, users(:bender).bot_key), params: +body
+      Message.last
+    end
 end


### PR DESCRIPTION
Implements https://github.com/basecamp/once-campfire/discussions/236, where @monorkin suggested exposing both update and destroy while keeping the `can_administer?` check.

## Why

Bots can only create. A lifecycle notification — an alert that fires and later resolves, a deploy that starts and finishes, a backup that runs — has to post a second message, so the room becomes an append-only log of states rather than a view of the current one.

I hit this bridging Prometheus Alertmanager into a room: every alert costs two messages, and the resolved one is only meaningful if you remember the firing one.

## What

Two routes inside the existing `bot_key` scope:

```ruby
patch  ":bot_key/messages/:id", to: "messages/by_bots#update", as: :bot_message
delete ":bot_key/messages/:id", to: "messages/by_bots#destroy"
```

The body is read exactly the way `create` reads it, so updating a message is the same request shape as posting one:

```bash
curl -X PATCH -d "Deploy finished ✅" https://chat.example.com/rooms/1/<bot-key>/messages/42
```

## Authorization is unchanged

Nothing new was needed, which was the appeal of the idea.

`update` and `destroy` already run through `ensure_can_administer`, and `can_administer?` grants access only to a record the user created — so a bot key reaches that bot's own messages and no others. `set_room` narrows it again by looking the room up through the bot's own memberships.

A leaked bot key therefore gains what it could already do by posting: write to rooms that bot belongs to. It cannot edit anyone else's messages, and it cannot reach a room the bot isn't in.

## One thing worth a look in review

`destroy` can call `super` and then `head :no_content`, because the parent renders implicitly — the same reason `create` already works that way.

`update` can't: the parent redirects *inside* the action, so `super` followed by `head` would double render. Rather than duplicate the update and its broadcast in the bot controller, I extracted them into `MessagesController#update_message`. The web action keeps its redirect and behaves exactly as before; the bot path reuses both and answers `head :ok`.

If you'd prefer that split done differently — a `respond_to`, or an overridable response method — I'm happy to rework it.

## Tests

Eight added to `test/controllers/messages/by_bots_controller_test.rb`: update, update with UTF-8 content, destroy, and the abuse cases — editing a message the bot didn't create (403), reaching a room the bot isn't a member of, forging a bot key as another user, and the same for destroy.

`14 runs, 32 assertions, 0 failures`. One error remains in `create_file`, which fails the same way on a clean checkout here — my machine has no libvips.