### PR TITLE
Take the SSRF address policy from surfguard instead of keeping our own copy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "rails_autolink"
 gem "geared_pagination"
 gem "jbuilder"
 gem "net-http-persistent"
+gem "surfguard", github: "basecamp/surfguard" # The SSRF address policy behind RestrictedHTTP
 gem "kredis"
 gem "platform_agent"
 gem "thruster"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/basecamp/surfguard.git
-  revision: 0972277a8116412ac7ab35e9b512a99e700ef4b6
+  revision: 910be917fd0ab782c5ea939698d44f26694a501d
   specs:
     surfguard (0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/basecamp/surfguard.git
+  revision: 0972277a8116412ac7ab35e9b512a99e700ef4b6
+  specs:
+    surfguard (0.1.0)
+
+GIT
   remote: https://github.com/hotwired/turbo-rails.git
   revision: 30cd8fcc6f82c1ad4edd1ed6069ba878f21f02b3
   specs:
@@ -442,6 +448,7 @@ DEPENDENCIES
   sentry-ruby
   sqlite3
   stimulus-rails
+  surfguard!
   thruster
   turbo-rails!
   web-push

--- a/lib/restricted_http/private_network_guard.rb
+++ b/lib/restricted_http/private_network_guard.rb
@@ -1,76 +1,22 @@
-require "ipaddr"
-require "resolv"
+require "surfguard"
 
 module RestrictedHTTP
   class Violation < StandardError; end
 
+  # The address policy lives in the surfguard gem so this app, Basecamp, HEY and
+  # Fizzy classify "internal" the same way instead of each keeping a copy that
+  # drifts. The callers here hand a bare hostname in and pin the address that
+  # comes back, so this stays a hostname-in, address-out shim.
   module PrivateNetworkGuard
     extend self
 
-    # IPv4 special-use ranges (RFC 5735/6890) not already covered by the
-    # private?/loopback?/link_local? predicates in #disallowed_ipv4?.
-    DISALLOWED_IPV4 = %w[
-      0.0.0.0/8 100.64.0.0/10 192.0.0.0/24 192.0.2.0/24 192.88.99.0/24
-      198.18.0.0/15 198.51.100.0/24 203.0.113.0/24 224.0.0.0/4 240.0.0.0/4
-    ].map { |cidr| IPAddr.new(cidr) }.freeze
-
-    # IPv6 special-use ranges not caught by the predicates. 6to4 (2002::/16) and
-    # Teredo (2001::/32) are deprecated transition mechanisms with no legitimate
-    # fetch target, so they are blocked outright. ULA (fc00::/7, incl. the AWS
-    # IMDSv6 address fd00:ec2::254), link-local, and loopback are covered by the
-    # predicates in #disallowed_ipv6?.
-    DISALLOWED_IPV6 = %w[
-      ::/128 100::/64 2001::/32 2001:2::/48 2001:db8::/32 2002::/16
-      fec0::/10 ff00::/8
-    ].map { |cidr| IPAddr.new(cidr) }.freeze
-
-    # NAT64 prefixes: the well-known prefix (RFC 6052/6146) and the local-use
-    # prefix (RFC 8215). An address here embeds an IPv4 target in its low 32
-    # bits; we extract it and re-check against the IPv4 rules so NAT64 to a
-    # public address still resolves while NAT64 to an internal address is
-    # blocked.
-    NAT64_PREFIXES = [
-      IPAddr.new("64:ff9b::/96"),
-      IPAddr.new("64:ff9b:1::/48")
-    ].freeze
-
     def resolve(hostname)
-      Resolv.getaddress(hostname).tap do |ip|
-        raise Violation.new("Attempt to access private IP via #{hostname}") if ip && private_ip?(ip)
-      end
+      Surfguard.resolve_public_ips(hostname).first or
+        raise Violation.new("Attempt to access private IP via #{hostname}")
     end
 
     def private_ip?(ip)
-      ipaddr = IPAddr.new(ip)
-
-      # DNS never legitimately returns these embedded forms, so block them all
-      # regardless of the address they wrap.
-      if ipaddr.ipv4_mapped? || ipaddr.ipv4_compat?
-        true
-      elsif ipaddr.ipv4?
-        disallowed_ipv4?(ipaddr)
-      elsif NAT64_PREFIXES.any? { |prefix| prefix.include?(ipaddr) }
-        disallowed_ipv4?(embedded_ipv4(ipaddr))
-      else
-        disallowed_ipv6?(ipaddr)
-      end
-    rescue IPAddr::InvalidAddressError
-      true
+      Surfguard.blocked_address?(ip)
     end
-
-    private
-      def disallowed_ipv4?(ipaddr)
-        ipaddr.private? || ipaddr.loopback? || ipaddr.link_local? ||
-          DISALLOWED_IPV4.any? { |range| range.include?(ipaddr) }
-      end
-
-      def disallowed_ipv6?(ipaddr)
-        ipaddr.private? || ipaddr.loopback? || ipaddr.link_local? ||
-          DISALLOWED_IPV6.any? { |range| range.include?(ipaddr) }
-      end
-
-      def embedded_ipv4(ipaddr)
-        IPAddr.new([ ipaddr.to_i & 0xffffffff ].pack("N").unpack("C4").join("."))
-      end
   end
 end

--- a/lib/restricted_http/private_network_guard.rb
+++ b/lib/restricted_http/private_network_guard.rb
@@ -10,6 +10,13 @@ module RestrictedHTTP
   module PrivateNetworkGuard
     extend self
 
+    # A hostname that resolves to nothing (NXDOMAIN, timeout, empty answer)
+    # raises Surfguard::Unresolvable, which we let propagate as a lookup failure
+    # -- the same way the old Resolv.getaddress guard raised Resolv::ResolvError,
+    # and the callers here already treat it as a fetch failure. The Violation is
+    # reserved for a host that resolves to a blocked address (an empty list back
+    # from resolve_public_ips), so a transient DNS miss is never misreported as
+    # an SSRF attempt.
     def resolve(hostname)
       Surfguard.resolve_public_ips(hostname).first or
         raise Violation.new("Attempt to access private IP via #{hostname}")

--- a/test/lib/restricted_http/private_network_guard_test.rb
+++ b/test/lib/restricted_http/private_network_guard_test.rb
@@ -140,6 +140,13 @@ class RestrictedHTTP::PrivateNetworkGuardTest < ActiveSupport::TestCase
     assert_equal "93.184.216.34", RestrictedHTTP::PrivateNetworkGuard.resolve("example.com")
   end
 
+  test "resolve raises Unresolvable, not Violation, when the host resolves to nothing" do
+    Resolv.stubs(:getaddresses).returns([])
+    assert_raises Surfguard::Unresolvable do
+      RestrictedHTTP::PrivateNetworkGuard.resolve("nxdomain.example.com")
+    end
+  end
+
   private
     def assert_private_ip(address)
       assert RestrictedHTTP::PrivateNetworkGuard.private_ip?(address),

--- a/test/lib/restricted_http/private_network_guard_test.rb
+++ b/test/lib/restricted_http/private_network_guard_test.rb
@@ -74,12 +74,27 @@ class RestrictedHTTP::PrivateNetworkGuardTest < ActiveSupport::TestCase
     assert_private_ip "64:ff9b::a00:5"       # NAT64 -> 10.0.0.5
   end
 
-  test "private_ip? returns true for local-use NAT64 addresses embedding a private IPv4 (RFC8215)" do
-    assert_private_ip "64:ff9b:1::a00:1"  # local-use NAT64 -> 10.0.0.1
+  # The local-use block is refused whole rather than decoded. A Pref64 inside it
+  # can be any length from /32 to /96 and the position is not recoverable from
+  # the address alone (RFC 6052 §2.2), so reading the low 32 bits reads the
+  # wrong octets -- 64:ff9b:1::808:808 only looks like 8.8.8.8 under a /96
+  # reading. The block is never globally routed, so nothing legitimate is lost.
+  test "private_ip? returns true for the whole local-use NAT64 block (RFC8215)" do
+    assert_private_ip "64:ff9b:1::a00:1"    # reads as 10.0.0.1 under a /96
+    assert_private_ip "64:ff9b:1::808:808"  # reads as 8.8.8.8 under a /96
+    assert_private_ip "64:ff9b:1:ffff::1"
   end
 
-  test "private_ip? returns false for local-use NAT64 addresses embedding a public IPv4 (RFC8215)" do
-    assert_not RestrictedHTTP::PrivateNetworkGuard.private_ip?("64:ff9b:1::808:808")  # -> 8.8.8.8
+  # SIIT is the third way an IPv4 address rides inside an IPv6 one and the only
+  # one Ruby has no predicate for: ipv4_mapped?, ipv4_compat?, private?,
+  # loopback? and link_local? are all false here. Note the extra group --
+  # ::ffff:0:0:0/96 is not the IPv4-mapped ::ffff:0:0/96, and they do not
+  # overlap -- so this reached the metadata endpoint unrecognised.
+  test "private_ip? returns true for SIIT IPv4-translated addresses (RFC2765)" do
+    assert_private_ip "::ffff:0:169.254.169.254"
+    assert_private_ip "::ffff:0:a9fe:a9fe"        # the same address, hex spelling
+    assert_private_ip "::ffff:0:127.0.0.1"
+    assert_private_ip "::ffff:0:192.168.0.1"
   end
 
   test "private_ip? returns false for NAT64 addresses embedding a public IPv4" do
@@ -114,14 +129,14 @@ class RestrictedHTTP::PrivateNetworkGuardTest < ActiveSupport::TestCase
   end
 
   test "resolve raises Violation for private hostname" do
-    Resolv.stubs(:getaddress).returns("192.168.1.1")
+    Resolv.stubs(:getaddresses).returns([ "192.168.1.1" ])
     assert_raises RestrictedHTTP::Violation do
       RestrictedHTTP::PrivateNetworkGuard.resolve("private.example.com")
     end
   end
 
   test "resolve returns IP for public hostname" do
-    Resolv.stubs(:getaddress).returns("93.184.216.34")
+    Resolv.stubs(:getaddresses).returns([ "93.184.216.34" ])
     assert_equal "93.184.216.34", RestrictedHTTP::PrivateNetworkGuard.resolve("example.com")
   end
 

--- a/test/models/opengraph/fetch_test.rb
+++ b/test/models/opengraph/fetch_test.rb
@@ -37,7 +37,7 @@ class Opengraph::FetchTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, "https://www.other.com/")
       .to_return(status: 200, body: "<body>ok<body>", headers: { content_type: "text/html" })
-    Resolv.stubs(:getaddress).with("www.other.com").returns("127.0.0.1")
+    Resolv.stubs(:getaddresses).with("www.other.com").returns([ "127.0.0.1" ])
 
     assert_raises RestrictedHTTP::Violation do
       @fetch.fetch_document(@url, ip: "1.2.3.4")
@@ -48,7 +48,7 @@ class Opengraph::FetchTest < ActiveSupport::TestCase
     # Allow but interrupt a real connection to demonstrate that we connect
     # to a resolved IP, not a hostname to re-resolve.
     WebMock.disable_net_connect! allow: [ @url.host ]
-    Resolv.stubs(:getaddress).with(@url.host).returns("1.2.3.4", "127.0.0.1")
+    Resolv.stubs(:getaddresses).with(@url.host).returns([ "1.2.3.4" ], [ "127.0.0.1" ])
     TCPSocket.expects(:open).with { |*args, **| args.first == @url.host }.never
     TCPSocket.expects(:open).with { |*args, **| args.first == "1.2.3.4" && args[1] == 443 }.throws(:dns_not_rebound)
 
@@ -65,7 +65,7 @@ class Opengraph::FetchTest < ActiveSupport::TestCase
     # Allow but interrupt a real connection to demonstrate that we connect
     # to a resolved IP, not a hostname to re-resolve.
     WebMock.disable_net_connect! allow: [ @url.host ]
-    Resolv.stubs(:getaddress).with(@url.host).returns("1.2.3.4", "127.0.0.1")
+    Resolv.stubs(:getaddresses).with(@url.host).returns([ "1.2.3.4" ], [ "127.0.0.1" ])
     TCPSocket.expects(:open).with { |*args, **| args.first == @url.host }.never
     TCPSocket.expects(:open).with { |*args, **| args.first == "1.2.3.4" && args[1] == 443 }.throws(:dns_not_rebound)
 

--- a/test/models/opengraph/location_test.rb
+++ b/test/models/opengraph/location_test.rb
@@ -14,7 +14,7 @@ class Opengraph::LocationTest < ActiveSupport::TestCase
   end
 
   test "private network urls" do
-    Resolv.stubs(:getaddress).with("www.example.com").returns("172.16.0.0")
+    Resolv.stubs(:getaddresses).with("www.example.com").returns([ "172.16.0.0" ])
 
     location = Opengraph::Location.new("https://www.example.com")
     assert_not location.valid?
@@ -22,7 +22,7 @@ class Opengraph::LocationTest < ActiveSupport::TestCase
   end
 
   test "link-local addresses are blocked" do
-    Resolv.stubs(:getaddress).with("metadata.internal").returns("169.254.169.254")
+    Resolv.stubs(:getaddresses).with("metadata.internal").returns([ "169.254.169.254" ])
 
     location = Opengraph::Location.new("https://metadata.internal")
     assert_not location.valid?
@@ -30,13 +30,13 @@ class Opengraph::LocationTest < ActiveSupport::TestCase
   end
 
   test "IPv6 addresses mapped to IPv4 addresses are blocked" do
-    Resolv.stubs(:getaddress).with("metadata.internal").returns("::ffff:192.168.1.1")
+    Resolv.stubs(:getaddresses).with("metadata.internal").returns([ "::ffff:192.168.1.1" ])
 
     location = Opengraph::Location.new("https://metadata.internal")
     assert_not location.valid?
     assert_equal [ "is not public" ], location.errors[:url]
 
-    Resolv.stubs(:getaddress).with("metadata.internal").returns("::ffff:c0a8:0101")
+    Resolv.stubs(:getaddresses).with("metadata.internal").returns([ "::ffff:c0a8:0101" ])
 
     location = Opengraph::Location.new("https://metadata.internal")
     assert_not location.valid?


### PR DESCRIPTION
`RestrictedHTTP::PrivateNetworkGuard` classifies whether a resolved address is internal before an outbound fetch (OpenGraph unfurling, etc.) is allowed to reach it. It did that with its own inline copy of the rules — IPv4/IPv6 private ranges, NAT64 and IPv4-mapped decoding, the `InvalidAddress → treat as private` fallback.

This moves that policy into the [`surfguard`](https://github.com/basecamp/surfguard) gem so the address classification lives in one place instead of a copy per app. The guard stays a thin **hostname-in, address-out** shim: callers still hand it a bare hostname and pin the address that comes back, and `resolve` still raises `RestrictedHTTP::Violation` when the resolved address is internal.

### What changes

- `resolve` now calls `Surfguard.resolve_public_ips(hostname)` and raises `Violation` when the host resolves but every address is internal; `private_ip?` delegates to `Surfguard.blocked_address?`.
- The inline `DISALLOWED_IPV4` / `DISALLOWED_IPV6` / `NAT64_PREFIXES` tables and the private `disallowed_ipv4?` / `disallowed_ipv6?` / `embedded_ipv4` helpers are deleted — surfguard owns them now.
- A DNS lookup failure is now told apart from a block: surfguard raises `Surfguard::Unresolvable` when the host resolves to nothing at all, so a transient DNS miss surfaces as a lookup failure (which callers already swallow, as they did the old `Resolv::ResolvError`) rather than being misreported as a private-IP `Violation`.
- Behavior is preserved for the cases the old code already covered, and surfguard closes a gap the old code decoded loosely — the RFC 8215 local-use NAT64 block (`64:ff9b:1::/48`), whose embedded IPv4 is unrecoverable (Pref64 length is not carried in the address), is now blocked as a whole block. The RFC 6052 well-known NAT64 prefix and RFC 2765 SIIT IPv4-translated forms are still **decoded and their embedded IPv4 re-checked** — so an internal target wrapped in one (the metadata address, loopback, RFC 1918) is refused, while a public target inside them resolves. New tests cover the internal-embedded cases.
- Test stubs move from `Resolv.getaddress` (single string) to `Resolv.getaddresses` (array), matching how surfguard resolves.

### Gem source

surfguard isn't published to RubyGems yet, so the `Gemfile` tracks it by git (`gem "surfguard", github: "basecamp/surfguard"`) and `Gemfile.lock` pins the revision; the git pin is fine to review against until the gem is released.

### Verification

`bin/rails test` over the three touched test files — `restricted_http/private_network_guard_test.rb`, `opengraph/fetch_test.rb`, `opengraph/location_test.rb` — passes: **42 runs, 89 assertions, 0 failures, 0 errors** (the extra run is a regression test asserting a DNS miss raises `Unresolvable`, not `Violation`).
