### PR TITLE
Update mail to 2.9.1 for GHSA-mvxr-6m87-mv2q

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
Bumps the mail gem 2.9.0 → 2.9.1, the patch release for [GHSA-mvxr-6m87-mv2q](https://github.com/advisories/GHSA-mvxr-6m87-mv2q) (CVE-2026-63435, email address spoofing via malformed RFC 2047 encoded-words). The advisory landed in ruby-advisory-db on 2026-08-18, so the gem audit is red until this lands.

Conservative update — the Gemfile.lock diff moves only the mail version line. `bin/bundler-audit check --update` passes clean after the bump: no other advisories outstanding.