### PR TITLE
Bump brakeman to 8.0.6 and stop --ensure-latest reddening CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       semver-minor-days: 3
       semver-patch-days: 2
       default-days: 7
+      exclude:
+        - "brakeman"
 
   - package-ecosystem: docker
     directory: "/"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,6 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+ARGV.unshift("--ensure-latest", "15")
 
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
Brakeman 8.0.6 shipped on 2026-08-12. `bin/brakeman` force-injects `--ensure-latest`, which exits **5** the moment a newer release exists — so this build has been red since then, not merely stale.

Three commits:

1. **Lockfile bump to 8.0.6**, via `bundle lock --update brakeman`. brakeman's only runtime dependency is `racc` and its required ruby is `>= 3.2.0`, both unchanged since 7.1.2, so the diff is the one version line and nothing else in the graph moves.
2. **A 15-day grace period on `--ensure-latest`.** The flag takes an optional minimum age in days; without it, a release fails the build instantly. 15 is the maximum brakeman accepts — `lib/brakeman/options.rb` rejects anything outside 1–15.
3. **brakeman exempted from the dependabot cooldown**, so the next bump PR opens the week it ships rather than 7–14 days later. The 15-day window is only headroom if the PR actually arrives inside it; a weekly schedule plus a 7-day cooldown can eat 14 of those days on its own.

**Verified locally**

- The lockfile diff is the brakeman line only.
- brakeman 8.0.6 scans this repo clean: 0 warnings, 0 errors, 0 obsolete ignore entries.
- `--ensure-latest 15` parses as `days_old = 15` rather than being swallowed as a positional argument — checked through `Brakeman::Options.parse` on this repo's exact `ARGV`, and `--ensure-latest 99` correctly aborts with `invalid argument`. Worth checking explicitly: had the DAYS argument been ignored, the flag would have stayed in its old strict mode and the whole recurrence fix would have been a silent no-op.

One of twelve repos in a fleet-wide sweep to 8.0.6.
