### PR TITLE
Bump actionlint and zizmor-action to current releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           advanced-security: false
 


### PR DESCRIPTION
Dependabot version updates are disabled for this repo, so the weekly `github-actions` group never proposed these — the pins have been frozen since they were added in March (#185).

- `rhysd/actionlint` v1.7.11 → v1.7.12
- `zizmorcore/zizmor-action` v0.5.2 → v0.6.2

v0.5.2 bundles zizmor 1.23.1, which flags `secrets-outside-env` at the default persona. That moved to the `auditor` persona in zizmor 1.24.0 after false positives; v0.6.2 bundles 1.29.0. Nine repos were stuck on v0.5.2; the other eight had dependabot PRs waiting and are now merged.

Both linters pass locally at the new versions (zizmor: no findings, 2 ignored, 7 suppressed).

Worth knowing separately: with version updates disabled, this repo's `.github/dependabot.yml` is inert — including the `cooldown.exclude: brakeman` added in #249. Only Dependabot *security* updates run here, which is why the only dependabot PRs in five months have been single-gem advisory bumps. Enabling version updates in Settings → Code security would let the config actually take effect.