### PR TITLE
Fix the dependabot.yml validation error that has kept version updates from ever running

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,4 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 2
       default-days: 7


### PR DESCRIPTION
`.github/dependabot.yml` has been invalid since it landed in #248. GitHub reports it on Insights → Dependency graph → Dependabot:

> Your `.github/dependabot.yml` contained invalid details
> The property `#/updates/2/cooldown/semver-major-days` is not supported for the package ecosystem `docker`.
> The property `#/updates/2/cooldown/semver-minor-days` is not supported for the package ecosystem `docker`.
> The property `#/updates/2/cooldown/semver-patch-days` is not supported for the package ecosystem `docker`.

The docker block copied bundler's cooldown wholesale; those three keys only apply to ecosystems whose versions Dependabot classifies as semver, and container tags aren't. An invalid property invalidates the whole file, so `bundler` and `github-actions` have been dead too — this repo has never opened a version-update PR, and its only four Dependabot runs ever are single-gem security bumps, which don't read this file.

Consequences that are now explained:

- #249's `cooldown.exclude: brakeman` has never been exercised.
- #250's workflow linter pins had to be bumped by hand while every other repo got a Dependabot PR.
- `bin/brakeman` forces `--ensure-latest 15` against a lock pinned to brakeman 8.0.6. Nothing here could ever bump it, so CI was set to go red about 15 days after 8.0.7 ships.

`docker` keeps `default-days: 7`, which every ecosystem supports.

Worth watching after merge: the base image is `FROM docker.io/library/ruby:$RUBY_VERSION-slim` with `ARG RUBY_VERSION=3.4.5`. Dependabot handles parameterised tags poorly, so if `bundler` and `github-actions` start producing PRs and `docker` stays silent, that's a separate issue, not this one.

No other repo in the fleet configures a `docker` ecosystem, so this shape is unique to once-campfire.