### PR TITLE
Add missing vips/libvips dependency to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -58,14 +58,14 @@ echo
 
 # Install dependencies
 if command -v brew &>/dev/null; then
-  step "Installing packages" brew install sqlite ffmpeg mise
+  step "Installing packages" brew install sqlite ffmpeg mise vips
 elif command -v pacman &>/dev/null; then
-  packages=(sqlite ffmpeg mise)
+  packages=(sqlite ffmpeg mise libvips)
   if ! pacman -Q "${packages[@]}" >/dev/null 2>&1; then
     step "Installing packages" sudo pacman -S --noconfirm --needed "${packages[@]}"
   fi
 elif command -v apt &>/dev/null; then
-  step "Installing packages" sudo apt-get install --no-install-recommends -y libsqlite3-0 ffmpeg
+  step "Installing packages" sudo apt-get install --no-install-recommends -y libsqlite3-0 ffmpeg libvips
 fi
 
 if ! command -v mise &>/dev/null; then


### PR DESCRIPTION
### Problem
When running `bin/setup` on a fresh development machine that doesn't have `libvips` pre-installed, the setup process aborts during `rails db:prepare` with the following error:

```
bin/rails aborted!
NoMethodError: undefined method 'block_untrusted' for module Vips (NoMethodError)

Vips.block_untrusted(true)
    ^^^^^^^^^^^^^^^^
/config/initializers/vips.rb:6:in '<top (required)>'
/config/environment.rb:5:in '<top (required)>'
/bin/rails:4:in '<main>'
Tasks: TOP => db:prepare => db:load_config => environment
(See full trace by running task with --trace)
```

This happens because the [recently added](https://github.com/basecamp/once-campfire/pull/226) `config/initializers/vips.rb` calls `Vips.block_untrusted` method, which fails if the underlying `libvips` system library is missing. This issue only affects local machines, as CI and Docker environments already install `libvips` as a dependency.

### Solution
Added `vips` (Homebrew) and `libvips` (Apt/Pacman) to the package installation step in `bin/setup`. 

This aligns the local development setup script with what is already expected and installed in both the `Dockerfile` and the CI workflow (`.github/workflows/ci.yml`).

I verified that before `config/initializers/vips.rb` was added, `bin/setup` ran successfully on machines without `libvips` because the library was not used during application boot.