### PR TITLE
Support Redis configuration with REDIS_URL env var

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: redis
-  url: redis://localhost:6379
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379" } %>
 
 development:
   <<: *default

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,1 @@
+Resque.redis = ENV.fetch("REDIS_URL") { "redis://localhost:6379" }


### PR DESCRIPTION
This adds support for overriding the Redis URL using an environment variable.

If anyone wants to deploy Campfire to Hatchbox, Heroku, Render, Railway, etc, this should make it a bit easier.

Default values for ActionCable and Resque remain the same.