### PR TITLE
feat: transcode video uploads with ffmpeg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "stimulus-rails"
 
 # Media handling
 gem "image_processing", ">= 1.2"
+gem "streamio-ffmpeg"
 
 # Telemetry
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,6 +379,8 @@ GEM
     sqlite3 (2.9.6-x86_64-linux-gnu)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
+    streamio-ffmpeg (3.0.2)
+      multi_json (~> 1.8)
     stringio (3.1.8)
     thor (1.4.0)
     thruster (0.1.23-aarch64-linux)
@@ -448,6 +450,7 @@ DEPENDENCIES
   sentry-ruby
   sqlite3
   stimulus-rails
+  streamio-ffmpeg
   surfguard!
   thruster
   turbo-rails!

--- a/app/controllers/messages/by_bots_controller.rb
+++ b/app/controllers/messages/by_bots_controller.rb
@@ -15,6 +15,8 @@ class Messages::ByBotsController < MessagesController
 
   def create
     super
+    return if performed?
+
     head :created, location: message_url(@message)
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,7 +19,8 @@ class MessagesController < ApplicationController
 
   def create
     set_room
-    @message = @room.messages.create_with_attachment!(transcoded_message_params)
+    attributes = transcoded_message_params
+    @message = @room.messages.create_with_attachment!(attributes)
 
     @message.broadcast_create
     deliver_webhooks_to_bots
@@ -31,6 +32,8 @@ class MessagesController < ApplicationController
     end
   rescue ActiveRecord::RecordNotFound
     render action: :room_not_found
+  ensure
+    VideoTranscoder.cleanup(attributes&.[](:attachment))
   end
 
   def show

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,10 +19,12 @@ class MessagesController < ApplicationController
 
   def create
     set_room
-    @message = @room.messages.create_with_attachment!(message_params)
+    @message = @room.messages.create_with_attachment!(transcoded_message_params)
 
     @message.broadcast_create
     deliver_webhooks_to_bots
+  rescue VideoTranscoder::TranscodeError
+    redirect_to root_url, alert: "Video attachment could not be processed"
   rescue ActiveRecord::RecordNotFound
     render action: :room_not_found
   end
@@ -73,6 +75,14 @@ class MessagesController < ApplicationController
 
     def message_params
       params.require(:message).permit(:body, :attachment, :client_message_id)
+    end
+
+    def transcoded_message_params
+      attributes = message_params
+      if attributes[:attachment]
+        attributes[:attachment] = VideoTranscoder.call(attributes[:attachment])
+      end
+      attributes
     end
 
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -24,7 +24,11 @@ class MessagesController < ApplicationController
     @message.broadcast_create
     deliver_webhooks_to_bots
   rescue VideoTranscoder::TranscodeError
-    redirect_to root_url, alert: "Video attachment could not be processed"
+    if request.format.json?
+      head :unprocessable_content
+    else
+      redirect_to root_url, alert: "Video attachment could not be processed"
+    end
   rescue ActiveRecord::RecordNotFound
     render action: :room_not_found
   end

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -41,9 +41,11 @@ class VideoTranscoder
 
       movie = FFMPEG::Movie.new(io.path)
       movie.valid? &&
+        movie.container.to_s.split(",").include?("mp4") &&
         movie.video_codec == "h264" &&
+        movie.colorspace == "yuv420p" &&
         (movie.audio_codec.nil? || movie.audio_codec == "aac")
-    rescue FFMPEG::Error, Errno::ENOENT
+    rescue FFMPEG::Error, Errno::ENOENT, RuntimeError
       false # unprovable input falls through to transcoding, which fails cleanly
     end
 
@@ -59,9 +61,8 @@ class VideoTranscoder
       options = {
         video_codec: "libx264",
         audio_codec: "aac",
-        movflags: "+faststart",
-        preset: "medium",
-        crf: 23
+        x264_preset: "medium",
+        custom: [ "-movflags", "+faststart", "-crf", 23, "-pix_fmt", "yuv420p" ]
       }
 
       movie.transcode(output_path, options) do |progress|

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -1,8 +1,13 @@
 require "streamio-ffmpeg"
+require "tempfile"
+require "timeout"
 
 class VideoTranscoder
   # Videos larger than this are attached as-is to avoid tying up request workers with long transcodes.
   MAX_INPUT_SIZE = 200.megabytes
+  MAX_DURATION = 1.hour
+  MAX_TRANSCODE_TIME = 5.minutes
+  MP4_MAJOR_BRANDS = %w[ isom iso2 iso3 iso4 iso5 iso6 iso8 iso9 mp41 mp42 ].freeze
 
   # Raised when a video upload fails to transcode.
   class TranscodeError < StandardError; end
@@ -11,20 +16,24 @@ class VideoTranscoder
     new(io).call
   end
 
+  def self.cleanup(attachment)
+    io = attachment[:io] if attachment.is_a?(Hash)
+    io.close! if io.respond_to?(:close!)
+  end
+
   def initialize(io)
     @io = io
   end
 
   def call
     return io unless video?
-    return io if compatible_encoding?
+    return io if too_large?
 
-    if too_large?
-      Rails.logger.info "Skipping video transcoding: input exceeds #{MAX_INPUT_SIZE} bytes"
-      io
-    else
-      transcoded_io
-    end
+    movie = probe_movie
+    return io if compatible_encoding?(movie)
+    return io if too_long?(movie)
+
+    transcoded_io(movie)
   end
 
   private
@@ -36,27 +45,39 @@ class VideoTranscoder
 
     # Only mp4 uploads can be attached as-is, and only when their encoding is
     # already browser-compatible: h264 video and aac (or no) audio.
-    def compatible_encoding?
+    def probe_movie
+      FFMPEG::Movie.new(io.path)
+    rescue FFMPEG::Error, Errno::ENOENT, RuntimeError => error
+      raise TranscodeError, error.message
+    end
+
+    def compatible_encoding?(movie)
       return false unless io.content_type == "video/mp4"
 
-      movie = FFMPEG::Movie.new(io.path)
       movie.valid? &&
-        movie.container.to_s.split(",").include?("mp4") &&
+        MP4_MAJOR_BRANDS.include?(movie.format_tags&.[](:major_brand).to_s.strip.downcase) &&
         movie.video_codec == "h264" &&
         movie.colorspace == "yuv420p" &&
         (movie.audio_codec.nil? || movie.audio_codec == "aac")
-    rescue FFMPEG::Error, Errno::ENOENT, RuntimeError
-      false # unprovable input falls through to transcoding, which fails cleanly
     end
 
     def too_large?
-      io.size > MAX_INPUT_SIZE
+      if io.size > MAX_INPUT_SIZE
+        Rails.logger.info "Skipping video transcoding: input exceeds #{MAX_INPUT_SIZE} bytes"
+        true
+      end
     end
 
-    def transcoded_io
-      output_path = File.join(Dir.tmpdir, "transcoded_#{SecureRandom.hex}.mp4")
+    def too_long?(movie)
+      if movie.duration > MAX_DURATION
+        Rails.logger.info "Skipping video transcoding: duration exceeds #{MAX_DURATION} seconds"
+        true
+      end
+    end
 
-      movie = FFMPEG::Movie.new(io.path)
+    def transcoded_io(movie)
+      output = Tempfile.new([ "transcoded_", ".mp4" ])
+      output.binmode
 
       options = {
         video_codec: "libx264",
@@ -65,20 +86,25 @@ class VideoTranscoder
         custom: [ "-movflags", "+faststart", "-crf", 23, "-pix_fmt", "yuv420p" ]
       }
 
-      movie.transcode(output_path, options) do |progress|
-        Rails.logger.info "Transcoding progress: #{(progress * 100).round}%"
+      Timeout.timeout(MAX_TRANSCODE_TIME) do
+        movie.transcode(output.path, options) do |progress|
+          Rails.logger.info "Transcoding progress: #{(progress * 100).round}%"
+        end
       end
+      output.rewind
 
-      {
-        io: StringIO.new(File.binread(output_path)),
+      result = {
+        io: output,
         filename: "#{original_basename}.mp4",
         content_type: "video/mp4"
       }
+      output = nil
+      result
     rescue => error
       Rails.logger.error "Video transcoding failed: #{error.message}"
       raise TranscodeError, error.message
     ensure
-      File.delete(output_path) if output_path && File.exist?(output_path)
+      output&.close!
     end
 
     def original_basename

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -7,7 +7,7 @@ class VideoTranscoder
   MAX_INPUT_SIZE = 200.megabytes
   MAX_DURATION = 1.hour
   MAX_TRANSCODE_TIME = 5.minutes
-  MP4_MAJOR_BRANDS = %w[ isom iso2 iso3 iso4 iso5 iso6 iso8 iso9 mp41 mp42 ].freeze
+  MP4_MAJOR_BRANDS = %w[ isom iso2 iso3 iso4 iso5 iso6 iso8 iso9 mp41 mp42 mp71 avc1 avc2 avc3 avc4 m4v dash cmfc cmff ].freeze
 
   # Raised when a video upload fails to transcode.
   class TranscodeError < StandardError; end
@@ -31,7 +31,7 @@ class VideoTranscoder
 
     movie = probe_movie
     return io if compatible_encoding?(movie)
-    return io if too_long?(movie)
+    ensure_duration_supported!(movie)
 
     transcoded_io(movie)
   end
@@ -68,11 +68,11 @@ class VideoTranscoder
       end
     end
 
-    def too_long?(movie)
-      if movie.duration > MAX_DURATION
-        Rails.logger.info "Skipping video transcoding: duration exceeds #{MAX_DURATION} seconds"
-        true
-      end
+    def ensure_duration_supported!(movie)
+      return unless movie.duration > MAX_DURATION
+
+      Rails.logger.info "Rejecting video transcoding: duration exceeds #{MAX_DURATION} seconds"
+      raise TranscodeError, "Video exceeds maximum duration of #{MAX_DURATION} seconds"
     end
 
     def transcoded_io(movie)

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -5,7 +5,6 @@ require "timeout"
 class VideoTranscoder
   # Videos larger than this are attached as-is to avoid tying up request workers with long transcodes.
   MAX_INPUT_SIZE = 200.megabytes
-  MAX_DURATION = 1.hour
   MAX_TRANSCODE_TIME = 5.minutes
   MP4_MAJOR_BRANDS = %w[ isom iso2 iso3 iso4 iso5 iso6 iso8 iso9 mp41 mp42 mp71 avc1 avc2 avc3 avc4 m4v dash cmfc cmff ].freeze
 
@@ -31,7 +30,6 @@ class VideoTranscoder
 
     movie = probe_movie
     return io if compatible_encoding?(movie)
-    ensure_duration_supported!(movie)
 
     transcoded_io(movie)
   end
@@ -66,13 +64,6 @@ class VideoTranscoder
         Rails.logger.info "Skipping video transcoding: input exceeds #{MAX_INPUT_SIZE} bytes"
         true
       end
-    end
-
-    def ensure_duration_supported!(movie)
-      return unless movie.duration > MAX_DURATION
-
-      Rails.logger.info "Rejecting video transcoding: duration exceeds #{MAX_DURATION} seconds"
-      raise TranscodeError, "Video exceeds maximum duration of #{MAX_DURATION} seconds"
     end
 
     def transcoded_io(movie)

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -1,0 +1,87 @@
+require "streamio-ffmpeg"
+
+class VideoTranscoder
+  # Videos larger than this are attached as-is to avoid tying up request workers with long transcodes.
+  MAX_INPUT_SIZE = 200.megabytes
+
+  # Raised when a video upload fails to transcode.
+  class TranscodeError < StandardError; end
+
+  def self.call(io)
+    new(io).call
+  end
+
+  def initialize(io)
+    @io = io
+  end
+
+  def call
+    return io unless video?
+    return io if compatible_encoding?
+
+    if too_large?
+      Rails.logger.info "Skipping video transcoding: input exceeds #{MAX_INPUT_SIZE} bytes"
+      io
+    else
+      transcoded_io
+    end
+  end
+
+  private
+    attr_reader :io
+
+    def video?
+      io.content_type&.starts_with?("video/")
+    end
+
+    # Only mp4 uploads can be attached as-is, and only when their encoding is
+    # already browser-compatible: h264 video and aac (or no) audio.
+    def compatible_encoding?
+      return false unless io.content_type == "video/mp4"
+
+      movie = FFMPEG::Movie.new(io.path)
+      movie.valid? &&
+        movie.video_codec == "h264" &&
+        (movie.audio_codec.nil? || movie.audio_codec == "aac")
+    rescue FFMPEG::Error, Errno::ENOENT
+      false # unprovable input falls through to transcoding, which fails cleanly
+    end
+
+    def too_large?
+      io.size > MAX_INPUT_SIZE
+    end
+
+    def transcoded_io
+      output_path = File.join(Dir.tmpdir, "transcoded_#{SecureRandom.hex}.mp4")
+
+      movie = FFMPEG::Movie.new(io.path)
+
+      options = {
+        video_codec: "libx264",
+        audio_codec: "aac",
+        movflags: "+faststart",
+        preset: "medium",
+        crf: 23
+      }
+
+      movie.transcode(output_path, options) do |progress|
+        Rails.logger.info "Transcoding progress: #{(progress * 100).round}%"
+      end
+
+      {
+        io: StringIO.new(File.binread(output_path)),
+        filename: "#{original_basename}.mp4",
+        content_type: "video/mp4"
+      }
+    rescue => error
+      Rails.logger.error "Video transcoding failed: #{error.message}"
+      raise TranscodeError, error.message
+    ensure
+      File.delete(output_path) if output_path && File.exist?(output_path)
+    end
+
+    def original_basename
+      basename = File.basename(io.original_filename.to_s, ".*").presence
+      basename || "video"
+    end
+end

--- a/test/controllers/messages/by_bots_controller_test.rb
+++ b/test/controllers/messages/by_bots_controller_test.rb
@@ -26,6 +26,22 @@ class Messages::ByBotsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "create video returns unprocessable content when transcoding fails" do
+    movie = mock("movie")
+    movie.stubs(:transcode).raises(RuntimeError, "ffmpeg exploded")
+    FFMPEG::Movie.stubs(:new).returns(movie)
+
+    assert_no_difference -> { Message.count } do
+      post room_bot_messages_url(@room, users(:bender).bot_key), params: {
+        attachment: fixture_file_upload("alpha-centuri.mov", "video/quicktime")
+      }
+    end
+
+    assert_response :unprocessable_content
+  ensure
+    FFMPEG::Movie.unstub(:new)
+  end
+
   test "create does not trigger a webhook to the sending bot if it mentions itself" do
     body = "<div>Hey #{mention_attachment_for(:bender)}</div>"
 

--- a/test/controllers/messages/by_bots_controller_test.rb
+++ b/test/controllers/messages/by_bots_controller_test.rb
@@ -28,6 +28,7 @@ class Messages::ByBotsControllerTest < ActionDispatch::IntegrationTest
 
   test "create video returns unprocessable content when transcoding fails" do
     movie = mock("movie")
+    movie.stubs(:duration).returns(0)
     movie.stubs(:transcode).raises(RuntimeError, "ffmpeg exploded")
     FFMPEG::Movie.stubs(:new).returns(movie)
 

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -148,6 +148,39 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "creating a message with a video attachment transcodes it to mp4" do
+    movie = mock("movie")
+    movie.stubs(:transcode).with do |output_path, _options|
+      File.binwrite(output_path, File.binread(Rails.root.join("test/fixtures/files/alpha-centuri.mov")))
+      true
+    end
+    FFMPEG::Movie.stubs(:new).returns(movie)
+
+    post room_messages_url(@room, format: :turbo_stream), params: { message: {
+      body: "New one", client_message_id: 999,
+      attachment: fixture_file_upload("alpha-centuri.mov", "video/quicktime") } }
+
+    assert_response :success
+    assert_equal "video/mp4", Message.last.attachment.blob.content_type
+  end
+
+  test "creating a message with a video attachment that fails to transcode redirects with an alert" do
+    movie = mock("movie")
+    movie.stubs(:transcode).raises(RuntimeError, "ffmpeg exploded")
+    FFMPEG::Movie.stubs(:new).returns(movie)
+
+    assert_no_difference -> { Message.count } do
+      post room_messages_url(@room, format: :turbo_stream), params: { message: {
+        body: "New one", client_message_id: 999,
+        attachment: fixture_file_upload("alpha-centuri.mov", "video/quicktime") } }
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Video attachment could not be processed", flash[:alert]
+  ensure
+    FFMPEG::Movie.unstub(:new)
+  end
+
   private
     def ensure_messages_present(*messages, count: 1)
       messages.each do |message|

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -150,6 +150,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
   test "creating a message with a video attachment transcodes it to mp4" do
     movie = mock("movie")
+    movie.stubs(:duration).returns(0)
     movie.stubs(:transcode).with do |output_path, _options|
       File.binwrite(output_path, File.binread(Rails.root.join("test/fixtures/files/alpha-centuri.mov")))
       true
@@ -166,6 +167,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
   test "creating a message with a video attachment that fails to transcode redirects with an alert" do
     movie = mock("movie")
+    movie.stubs(:duration).returns(0)
     movie.stubs(:transcode).raises(RuntimeError, "ffmpeg exploded")
     FFMPEG::Movie.stubs(:new).returns(movie)
 

--- a/test/services/video_transcoder_test.rb
+++ b/test/services/video_transcoder_test.rb
@@ -1,0 +1,149 @@
+require "test_helper"
+
+class VideoTranscoderTest < ActiveSupport::TestCase
+  test "passes through non-video attachments unchanged" do
+    upload = fake_upload(content_type: "image/jpeg")
+
+    FFMPEG::Movie.expects(:new).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "passes through mp4 uploads already encoded with h264/aac" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac")
+    movie.expects(:transcode).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "passes through silent mp4 uploads already encoded with h264" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: nil)
+    movie.expects(:transcode).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "transcodes mp4 uploads with an incompatible video codec" do
+    upload = fake_upload(content_type: "video/mp4", original_filename: "clip.mp4")
+
+    movie = stub_movie(video_codec: "hevc", audio_codec: "aac")
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    result = VideoTranscoder.call(upload)
+
+    assert_equal "clip.mp4", result[:filename]
+    assert_equal "video/mp4", result[:content_type]
+    assert_equal "transcoded mp4 data", result[:io].read
+  end
+
+  test "transcodes mp4 uploads with an incompatible audio codec" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "opus")
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+  end
+
+  test "transcodes mp4 uploads that cannot be probed" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(valid: false)
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+  end
+
+  test "raises TranscodeError when the upload cannot be probed at all" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    FFMPEG::Movie.stubs(:new).raises(FFMPEG::Error, "probe exploded")
+
+    error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
+    assert_equal "probe exploded", error.message
+  ensure
+    FFMPEG::Movie.unstub(:new)
+  end
+
+  test "skips transcoding videos larger than the maximum input size" do
+    upload = fake_upload(content_type: "video/quicktime", size: VideoTranscoder::MAX_INPUT_SIZE + 1)
+
+    FFMPEG::Movie.expects(:new).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "transcodes video uploads to an h264 mp4 and preserves the original filename" do
+    upload = fake_upload(content_type: "video/quicktime", original_filename: "clip.mov")
+
+    movie = stub_movie
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    result = VideoTranscoder.call(upload)
+
+    assert_equal "clip.mp4", result[:filename]
+    assert_equal "video/mp4", result[:content_type]
+    assert_equal "transcoded mp4 data", result[:io].read
+  end
+
+  test "falls back to a generic filename when the upload has none" do
+    upload = fake_upload(content_type: "video/quicktime", original_filename: nil)
+
+    movie = stub_movie
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    assert_equal "video.mp4", VideoTranscoder.call(upload)[:filename]
+  end
+
+  test "raises TranscodeError and leaves no temp files behind when transcoding fails" do
+    upload = fake_upload(content_type: "video/quicktime")
+
+    movie = stub_movie
+    stub_transcode_failure(movie, message: "ffmpeg exploded")
+
+    temp_files_before = Dir.glob(temp_transcode_files).length
+
+    error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
+    assert_equal "ffmpeg exploded", error.message
+    assert_equal temp_files_before, Dir.glob(temp_transcode_files).length
+  end
+
+
+  private
+    def fake_upload(content_type:, data: "video data", original_filename: "clip.mov", size: data.bytesize)
+      StringIO.new(data).tap do |io|
+        io.define_singleton_method(:content_type) { content_type }
+        io.define_singleton_method(:original_filename) { original_filename }
+        io.define_singleton_method(:path) { File.join(Dir.tmpdir, "fake_upload_#{SecureRandom.hex}") }
+        io.define_singleton_method(:size) { size }
+      end
+    end
+
+    def stub_movie(video_codec: nil, audio_codec: nil, valid: true)
+      movie = mock("movie")
+      movie.stubs(valid?: valid)
+      movie.stubs(video_codec: video_codec)
+      movie.stubs(audio_codec: audio_codec)
+      FFMPEG::Movie.stubs(:new).returns(movie)
+      movie
+    end
+
+    def stub_transcode_success(movie, output_data:)
+      movie.stubs(:transcode).with do |output_path, _options|
+        File.binwrite(output_path, output_data)
+        true
+      end
+    end
+
+    def stub_transcode_failure(movie, message:)
+      movie.stubs(:transcode).raises(RuntimeError, message)
+    end
+
+    def temp_transcode_files
+      File.join(Dir.tmpdir, "transcoded_*")
+    end
+end

--- a/test/services/video_transcoder_test.rb
+++ b/test/services/video_transcoder_test.rb
@@ -49,6 +49,24 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
   end
 
+  test "transcodes mp4 uploads with an incompatible container" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", container: "matroska,webm")
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+  end
+
+  test "transcodes mp4 uploads with an incompatible pixel format" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", colorspace: "yuv444p")
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+  end
+
   test "transcodes mp4 uploads that cannot be probed" do
     upload = fake_upload(content_type: "video/mp4")
 
@@ -69,6 +87,17 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     FFMPEG::Movie.unstub(:new)
   end
 
+  test "raises TranscodeError when ffprobe output cannot be parsed" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    FFMPEG::Movie.stubs(:new).raises(RuntimeError, "Could not parse output from FFProbe")
+
+    error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
+    assert_equal "Could not parse output from FFProbe", error.message
+  ensure
+    FFMPEG::Movie.unstub(:new)
+  end
+
   test "skips transcoding videos larger than the maximum input size" do
     upload = fake_upload(content_type: "video/quicktime", size: VideoTranscoder::MAX_INPUT_SIZE + 1)
 
@@ -81,7 +110,16 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     upload = fake_upload(content_type: "video/quicktime", original_filename: "clip.mov")
 
     movie = stub_movie
-    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+    movie.expects(:transcode).with do |output_path, options|
+      assert_equal({
+        video_codec: "libx264",
+        audio_codec: "aac",
+        x264_preset: "medium",
+        custom: [ "-movflags", "+faststart", "-crf", 23, "-pix_fmt", "yuv420p" ]
+      }, options)
+      File.binwrite(output_path, "transcoded mp4 data")
+      true
+    end
 
     result = VideoTranscoder.call(upload)
 
@@ -123,10 +161,12 @@ class VideoTranscoderTest < ActiveSupport::TestCase
       end
     end
 
-    def stub_movie(video_codec: nil, audio_codec: nil, valid: true)
+    def stub_movie(video_codec: nil, audio_codec: nil, container: "mov,mp4,m4a,3gp,3g2,mj2", colorspace: "yuv420p", valid: true)
       movie = mock("movie")
       movie.stubs(valid?: valid)
+      movie.stubs(container: container)
       movie.stubs(video_codec: video_codec)
+      movie.stubs(colorspace: colorspace)
       movie.stubs(audio_codec: audio_codec)
       FFMPEG::Movie.stubs(:new).returns(movie)
       movie

--- a/test/services/video_transcoder_test.rb
+++ b/test/services/video_transcoder_test.rb
@@ -33,11 +33,11 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie(video_codec: "hevc", audio_codec: "aac")
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    result = VideoTranscoder.call(upload)
-
-    assert_equal "clip.mp4", result[:filename]
-    assert_equal "video/mp4", result[:content_type]
-    assert_equal "transcoded mp4 data", result[:io].read
+    with_transcoded_result(upload) do |result|
+      assert_equal "clip.mp4", result[:filename]
+      assert_equal "video/mp4", result[:content_type]
+      assert_equal "transcoded mp4 data", result[:io].read
+    end
   end
 
   test "transcodes mp4 uploads with an incompatible audio codec" do
@@ -46,16 +46,31 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie(video_codec: "h264", audio_codec: "opus")
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+    with_transcoded_result(upload) do |result|
+      assert_equal "video/mp4", result[:content_type]
+    end
   end
 
   test "transcodes mp4 uploads with an incompatible container" do
     upload = fake_upload(content_type: "video/mp4")
 
-    movie = stub_movie(video_codec: "h264", audio_codec: "aac", container: "matroska,webm")
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", format_tags: { major_brand: "webm" })
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+    with_transcoded_result(upload) do |result|
+      assert_equal "video/mp4", result[:content_type]
+    end
+  end
+
+  test "transcodes MP4-declared MOV uploads" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", format_tags: { major_brand: "qt  " })
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+
+    with_transcoded_result(upload) do |result|
+      assert_equal "video/mp4", result[:content_type]
+    end
   end
 
   test "transcodes mp4 uploads with an incompatible pixel format" do
@@ -64,7 +79,9 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie(video_codec: "h264", audio_codec: "aac", colorspace: "yuv444p")
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+    with_transcoded_result(upload) do |result|
+      assert_equal "video/mp4", result[:content_type]
+    end
   end
 
   test "transcodes mp4 uploads that cannot be probed" do
@@ -73,7 +90,9 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie(valid: false)
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    assert_equal "video/mp4", VideoTranscoder.call(upload)[:content_type]
+    with_transcoded_result(upload) do |result|
+      assert_equal "video/mp4", result[:content_type]
+    end
   end
 
   test "raises TranscodeError when the upload cannot be probed at all" do
@@ -99,9 +118,18 @@ class VideoTranscoderTest < ActiveSupport::TestCase
   end
 
   test "skips transcoding videos larger than the maximum input size" do
-    upload = fake_upload(content_type: "video/quicktime", size: VideoTranscoder::MAX_INPUT_SIZE + 1)
+    upload = fake_upload(content_type: "video/mp4", size: VideoTranscoder::MAX_INPUT_SIZE + 1)
 
     FFMPEG::Movie.expects(:new).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "skips transcoding videos longer than the maximum duration" do
+    upload = fake_upload(content_type: "video/quicktime")
+
+    movie = stub_movie(duration: VideoTranscoder::MAX_DURATION + 1)
+    movie.expects(:transcode).never
 
     assert_same upload, VideoTranscoder.call(upload)
   end
@@ -121,11 +149,12 @@ class VideoTranscoderTest < ActiveSupport::TestCase
       true
     end
 
-    result = VideoTranscoder.call(upload)
-
-    assert_equal "clip.mp4", result[:filename]
-    assert_equal "video/mp4", result[:content_type]
-    assert_equal "transcoded mp4 data", result[:io].read
+    with_transcoded_result(upload) do |result|
+      assert_instance_of Tempfile, result[:io]
+      assert_equal "clip.mp4", result[:filename]
+      assert_equal "video/mp4", result[:content_type]
+      assert_equal "transcoded mp4 data", result[:io].read
+    end
   end
 
   test "falls back to a generic filename when the upload has none" do
@@ -134,7 +163,21 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie
     stub_transcode_success(movie, output_data: "transcoded mp4 data")
 
-    assert_equal "video.mp4", VideoTranscoder.call(upload)[:filename]
+    with_transcoded_result(upload) do |result|
+      assert_equal "video.mp4", result[:filename]
+    end
+  end
+
+  test "applies a hard timeout to transcoding" do
+    upload = fake_upload(content_type: "video/quicktime")
+
+    movie = stub_movie
+    stub_transcode_success(movie, output_data: "transcoded mp4 data")
+    Timeout.expects(:timeout).with(VideoTranscoder::MAX_TRANSCODE_TIME).yields
+
+    with_transcoded_result(upload) do |result|
+      assert_equal "transcoded mp4 data", result[:io].read
+    end
   end
 
   test "raises TranscodeError and leaves no temp files behind when transcoding fails" do
@@ -152,6 +195,13 @@ class VideoTranscoderTest < ActiveSupport::TestCase
 
 
   private
+    def with_transcoded_result(upload)
+      result = VideoTranscoder.call(upload)
+      yield result
+    ensure
+      VideoTranscoder.cleanup(result)
+    end
+
     def fake_upload(content_type:, data: "video data", original_filename: "clip.mov", size: data.bytesize)
       StringIO.new(data).tap do |io|
         io.define_singleton_method(:content_type) { content_type }
@@ -161,10 +211,12 @@ class VideoTranscoderTest < ActiveSupport::TestCase
       end
     end
 
-    def stub_movie(video_codec: nil, audio_codec: nil, container: "mov,mp4,m4a,3gp,3g2,mj2", colorspace: "yuv420p", valid: true)
+    def stub_movie(video_codec: nil, audio_codec: nil, duration: 0, container: "mov,mp4,m4a,3gp,3g2,mj2", format_tags: { major_brand: "isom" }, colorspace: "yuv420p", valid: true)
       movie = mock("movie")
       movie.stubs(valid?: valid)
+      movie.stubs(duration: duration)
       movie.stubs(container: container)
+      movie.stubs(format_tags: format_tags)
       movie.stubs(video_codec: video_codec)
       movie.stubs(colorspace: colorspace)
       movie.stubs(audio_codec: audio_codec)

--- a/test/services/video_transcoder_test.rb
+++ b/test/services/video_transcoder_test.rb
@@ -27,6 +27,24 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     assert_same upload, VideoTranscoder.call(upload)
   end
 
+  test "passes through MP4 uploads with the avc1 brand" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", format_tags: { major_brand: "avc1" })
+    movie.expects(:transcode).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
+  test "passes through MP4 uploads with the M4V brand" do
+    upload = fake_upload(content_type: "video/mp4")
+
+    movie = stub_movie(video_codec: "h264", audio_codec: "aac", format_tags: { major_brand: "M4V " })
+    movie.expects(:transcode).never
+
+    assert_same upload, VideoTranscoder.call(upload)
+  end
+
   test "transcodes mp4 uploads with an incompatible video codec" do
     upload = fake_upload(content_type: "video/mp4", original_filename: "clip.mp4")
 
@@ -125,13 +143,14 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     assert_same upload, VideoTranscoder.call(upload)
   end
 
-  test "skips transcoding videos longer than the maximum duration" do
+  test "rejects transcoding videos longer than the maximum duration" do
     upload = fake_upload(content_type: "video/quicktime")
 
     movie = stub_movie(duration: VideoTranscoder::MAX_DURATION + 1)
     movie.expects(:transcode).never
 
-    assert_same upload, VideoTranscoder.call(upload)
+    error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
+    assert_equal "Video exceeds maximum duration of #{VideoTranscoder::MAX_DURATION} seconds", error.message
   end
 
   test "transcodes video uploads to an h264 mp4 and preserves the original filename" do
@@ -186,11 +205,15 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     movie = stub_movie
     stub_transcode_failure(movie, message: "ffmpeg exploded")
 
-    temp_files_before = Dir.glob(temp_transcode_files).length
+    output = Tempfile.new([ "transcoded_", ".mp4" ])
+    output_path = output.path
+    Tempfile.expects(:new).with([ "transcoded_", ".mp4" ]).returns(output)
 
     error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
     assert_equal "ffmpeg exploded", error.message
-    assert_equal temp_files_before, Dir.glob(temp_transcode_files).length
+    assert_not File.exist?(output_path)
+  ensure
+    output&.close!
   end
 
 
@@ -211,11 +234,10 @@ class VideoTranscoderTest < ActiveSupport::TestCase
       end
     end
 
-    def stub_movie(video_codec: nil, audio_codec: nil, duration: 0, container: "mov,mp4,m4a,3gp,3g2,mj2", format_tags: { major_brand: "isom" }, colorspace: "yuv420p", valid: true)
+    def stub_movie(video_codec: nil, audio_codec: nil, duration: 0, format_tags: { major_brand: "isom" }, colorspace: "yuv420p", valid: true)
       movie = mock("movie")
       movie.stubs(valid?: valid)
       movie.stubs(duration: duration)
-      movie.stubs(container: container)
       movie.stubs(format_tags: format_tags)
       movie.stubs(video_codec: video_codec)
       movie.stubs(colorspace: colorspace)
@@ -233,9 +255,5 @@ class VideoTranscoderTest < ActiveSupport::TestCase
 
     def stub_transcode_failure(movie, message:)
       movie.stubs(:transcode).raises(RuntimeError, message)
-    end
-
-    def temp_transcode_files
-      File.join(Dir.tmpdir, "transcoded_*")
     end
 end

--- a/test/services/video_transcoder_test.rb
+++ b/test/services/video_transcoder_test.rb
@@ -143,16 +143,6 @@ class VideoTranscoderTest < ActiveSupport::TestCase
     assert_same upload, VideoTranscoder.call(upload)
   end
 
-  test "rejects transcoding videos longer than the maximum duration" do
-    upload = fake_upload(content_type: "video/quicktime")
-
-    movie = stub_movie(duration: VideoTranscoder::MAX_DURATION + 1)
-    movie.expects(:transcode).never
-
-    error = assert_raises(VideoTranscoder::TranscodeError) { VideoTranscoder.call(upload) }
-    assert_equal "Video exceeds maximum duration of #{VideoTranscoder::MAX_DURATION} seconds", error.message
-  end
-
   test "transcodes video uploads to an h264 mp4 and preserves the original filename" do
     upload = fake_upload(content_type: "video/quicktime", original_filename: "clip.mov")
 


### PR DESCRIPTION
## Problem

Video attachments in formats the browser can't reliably play back (e.g.
`.mov`, `.webm`, `.avi`) are stored and served as-is, so they often fail
to play for other users.

## Solution

Transcode video attachments to H.264/AAC MP4 (with `+faststart`) before
they're attached to a message, via a new `VideoTranscoder` service called
from `MessagesController#create`.

Uploads that don't need work pass through untouched:

- non-video attachments,
- MP4s already encoded with H.264 video + AAC audio (or no audio track),
  verified via ffprobe rather than trusting the content type,
- videos over `VideoTranscoder::MAX_INPUT_SIZE` (200 MB), which are
  attached as-is to avoid tying up a request worker with a long encode.

The original upload's filename is preserved (`clip.mov` → `clip.mp4`,
with a generic `video.mp4` fallback). If transcoding fails (corrupt
input, ffmpeg error, or the five-minute transcoding timeout), the message
is not created and the user is redirected back with an alert instead of
receiving a 500.

## Notes

- Requires the `ffmpeg`/`ffprobe` binaries at runtime; the Dockerfile
  already installs ffmpeg.
- Transcoding happens synchronously in the request; the 200 MB size guardrail
  avoids large encodes and the five-minute timeout caps the remaining work.