### PR TITLE
Require authentication for Active Storage direct uploads

### DIFF
--- a/app/controllers/concerns/active_storage_authentication.rb
+++ b/app/controllers/concerns/active_storage_authentication.rb
@@ -1,0 +1,9 @@
+module ActiveStorageAuthentication
+  extend ActiveSupport::Concern
+  include Authentication::SessionLookup
+
+  private
+    def require_active_storage_authentication
+      head :unauthorized unless find_session_by_cookie
+    end
+end

--- a/config/initializers/active_storage_authentication.rb
+++ b/config/initializers/active_storage_authentication.rb
@@ -1,0 +1,15 @@
+# Active Storage mounts its direct-upload write endpoints
+# (POST /rails/active_storage/direct_uploads and the disk-service PUT) on
+# framework controllers that inherit from ActiveStorage::BaseController, so
+# they never pass through ApplicationController's require_authentication.
+# Campfire uploads attachments through MessagesController instead and does not
+# use direct uploads at all, leaving these endpoints reachable by anyone who
+# can read the public login page. Require a valid Campfire session before an
+# anonymous caller can allocate a Blob or persist bytes to disk.
+Rails.application.config.to_prepare do
+  ActiveStorage::DirectUploadsController.include ActiveStorageAuthentication
+  ActiveStorage::DirectUploadsController.before_action :require_active_storage_authentication
+
+  ActiveStorage::DiskController.include ActiveStorageAuthentication
+  ActiveStorage::DiskController.before_action :require_active_storage_authentication, only: :update
+end

--- a/test/controllers/active_storage_authentication_test.rb
+++ b/test/controllers/active_storage_authentication_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class ActiveStorageAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "once.campfire.test"
+  end
+
+  test "direct upload metadata endpoint rejects anonymous callers" do
+    get new_session_url
+    assert_response :success
+
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      post rails_direct_uploads_url, params: blob_params, as: :json
+    end
+
+    assert_response :unauthorized
+  end
+
+  test "direct upload metadata endpoint allows authenticated users" do
+    sign_in :david
+
+    assert_difference -> { ActiveStorage::Blob.count }, 1 do
+      post rails_direct_uploads_url, params: blob_params, as: :json
+    end
+
+    assert_response :success
+  end
+
+  test "disk service upload endpoint rejects anonymous callers" do
+    sign_in :david
+    post rails_direct_uploads_url, params: blob_params, as: :json
+    assert_response :success
+    upload_path = URI.parse(response.parsed_body.dig("direct_upload", "url")).request_uri
+
+    anonymous = open_session
+    anonymous.host! "once.campfire.test"
+    anonymous.put upload_path,
+      params: attachment_bytes,
+      headers: { "Content-Type" => "application/octet-stream" }
+
+    assert_equal 401, anonymous.status
+  end
+
+  test "disk service download endpoint stays public" do
+    ActiveStorage::Current.url_options = { host: "once.campfire.test", protocol: "https" }
+    blob = ActiveStorage::Blob.create_and_upload! \
+      io: StringIO.new(attachment_bytes), filename: "hi.txt", content_type: "text/plain"
+    download_path = URI.parse(blob.url).request_uri
+
+    anonymous = open_session
+    anonymous.host! "once.campfire.test"
+    anonymous.get download_path
+
+    assert_equal 200, anonymous.status
+    assert_equal attachment_bytes, anonymous.response.body
+  ensure
+    blob&.purge
+  end
+
+  private
+    def attachment_bytes
+      "hello!"
+    end
+
+    def blob_params
+      { blob: {
+        filename: "quota.bin",
+        byte_size: attachment_bytes.bytesize,
+        checksum: Digest::MD5.base64digest(attachment_bytes),
+        content_type: "application/octet-stream"
+      } }
+    end
+end


### PR DESCRIPTION
## Problem

Active Storage mounts its direct-upload **write** endpoints on framework controllers that inherit from `ActiveStorage::BaseController`, not from `ApplicationController`:

- `POST /rails/active_storage/direct_uploads` (`ActiveStorage::DirectUploadsController#create`)
- `PUT  /rails/active_storage/disk/:token` (`ActiveStorage::DiskController#update`)

Because they bypass `ApplicationController`, they never run `require_authentication`. Anyone who can load the public `/session/new` page can lift a CSRF token and the Rails session cookie, POST to the metadata endpoint, and receive a signed disk PUT URL **without holding a Campfire `session_token`**.

That is enough to create `ActiveStorage::Blob` rows and persist bytes to disk anonymously. The blobs stay unattached (an anonymous caller can't create a message) and nothing purges them, so storage grows without bound. Since the recommended self-host layout co-locates uploaded files and the SQLite database on one `/rails/storage` volume, that growth eventually makes DB writes fail — blocking login and messaging until an admin frees space and purges the blobs.

## Fix

Campfire uploads attachments through `MessagesController` as a normal multipart `POST /rooms/:id/messages` (`message[attachment]`, see `app/javascript/models/file_uploader.js`) and does **not** use Active Storage direct uploads at all. These endpoints therefore have no legitimate anonymous caller.

- New `ActiveStorageAuthentication` concern requires a valid Campfire session (`find_session_by_cookie`) and returns `401` otherwise.
- Wired in via a `to_prepare` initializer onto `DirectUploadsController#create` and `DiskController#update`.
- **Serving is unchanged** — `disk#show`, representations, and blob redirects keep working; only the two write endpoints are gated.

## Tests

`test/controllers/active_storage_authentication_test.rb`:

- anonymous `direct_uploads` POST → `401`, creates **no** blob
- authenticated user → `200`, blob created (legit path preserved)
- anonymous disk-service PUT → `401`

Verified the test fails without the guard (anonymous blob created; PUT returns `204`) and passes with it. Full `bin/rails test` green (374 runs, 0 failures), rubocop clean, brakeman 0 warnings.