### PR TITLE
Close live Action Cable connections on sign out

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -71,6 +71,13 @@ module Authentication
       Current.session&.destroy!
       reset_session
       remove_authentication_cookie
+      disconnect_remote_connections
+    end
+
+    def disconnect_remote_connections
+      Current.user&.reset_remote_connections
+    rescue => error
+      Rails.logger.warn "Could not disconnect remote connections on sign out: #{error.class}"
     end
 
     def authenticated_as(session)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -56,6 +56,30 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil Session.find_by(id: session.id)
   end
 
+  test "destroy closes the signed-out user's live connections" do
+    sign_in :david
+
+    remote_connections = mock
+    remote_connections.expects(:disconnect).with(reconnect: true)
+    ActionCable.server.stubs(:remote_connections).returns(mock.tap { |m| m.expects(:where).with(current_user: users(:david)).returns(remote_connections) })
+
+    delete session_url
+
+    assert_redirected_to root_url
+  end
+
+  test "destroy still signs out when the realtime service is unreachable" do
+    sign_in :david
+    session = users(:david).sessions.last
+    ActionCable.server.stubs(:remote_connections).raises(RuntimeError.new("cable down"))
+
+    delete session_url
+
+    assert_redirected_to root_url
+    assert_not cookies[:session_token].present?
+    assert_nil Session.find_by(id: session.id)
+  end
+
   test "destroy removes the push subscription for the device" do
     sign_in :david
 


### PR DESCRIPTION
## Property

Action Cable authorizes a `Connection` once, at the WebSocket handshake, and never re-checks it. When a user signs out we destroy their `Session` record, which refuses future handshakes and any HTTP request carrying the revoked cookie. But a socket that was already open before sign out retains its handshake-time `current_user` and keeps authorizing new subscriptions and delivering frames — rooms, messages, presence, typing — as the signed-out user.

Signing out should also drop the user's live realtime connections.

## Fix

`terminate_current_session` now resets the current user's remote connections as part of sign out:

```ruby
def terminate_current_session
  Current.session&.destroy!
  reset_session
  remove_authentication_cookie
  disconnect_remote_connections
end
```

`reset_remote_connections` disconnects with `reconnect: true`, so every socket for the user tears down and re-handshakes:

- the **signed-out device** carries a destroyed session and a cleared cookie, so its reconnect is rejected at `find_verified_user` — the stale socket dies;
- the user's **other devices** with still-valid sessions reconnect and stay live, so signing out on one device doesn't silently freeze another.

This reuses the same primitive already used on membership removal (`app/models/user.rb`), for the same reason: connections must re-evaluate authorization.

The disconnect runs **last and best-effort** — after the session record and cookie are already gone — so a realtime-service outage can neither abort sign out nor leave the authentication cookie in place.

## Tests

Two regression tests in `SessionsControllerTest`:

- sign out fires the remote-connection reset for the signed-out user (`reconnect: true`);
- sign out still redirects, clears the cookie, and destroys the session when the realtime service raises.

Both verified RED→GREEN.

## Scope and residual

- Message posting is HTTP-gated and already refused once the session is destroyed, so this specifically closes the realtime read/presence/typing surface that a lingering socket kept open.
- Disconnects are user-wide rather than session-scoped: Action Cable's `RemoteConnections#where` requires every declared connection identifier, so scoping by session would break the user-wide disconnect that the deactivate, ban, and membership-removal paths depend on. `reconnect: true` keeps the user's other valid sessions live, so the user-wide reset carries only a brief, self-healing reconnect.
- This shares Action Cable's inherent limitation for any remote-disconnect-based revocation (already relied on by the deactivate and ban paths): a handshake completing in the narrow window between session destruction and the disconnect broadcast can miss that one-shot signal. Because the session record is already gone, such a socket is rejected on its next reconnect rather than persisting indefinitely. Durable per-subscription revalidation would be a larger, separate change.